### PR TITLE
Feature/#12-modifyInfo

### DIFF
--- a/src/main/java/com/likelion/RePlay/domain/info/entity/Info.java
+++ b/src/main/java/com/likelion/RePlay/domain/info/entity/Info.java
@@ -21,15 +21,18 @@ public class Info extends BaseEntity {
     @Column(name="INFO_ID")
     private Long infoId;
 
+    @Setter
     @Column(name = "TITLE")
     private String title;
 
+    @Setter
     @Column(name = "CONTENT")
     private String content;
 
     @Column(name="WRITER")
     private String writer; //작성자
 
+    @Setter
     @Column(name="INFO_NUM")
     private Long infoNum; //몇 호인지
 
@@ -47,4 +50,6 @@ public class Info extends BaseEntity {
         images.remove(infoImage);
         infoImage.setInfo(null);
     }
+
+
 }

--- a/src/main/java/com/likelion/RePlay/domain/info/service/InfoImageService.java
+++ b/src/main/java/com/likelion/RePlay/domain/info/service/InfoImageService.java
@@ -1,10 +1,8 @@
 package com.likelion.RePlay.domain.info.service;
 
 import com.likelion.RePlay.domain.info.entity.Info;
-import com.likelion.RePlay.domain.info.entity.InfoImage;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.IOException;
 import java.util.List;
 
 public interface InfoImageService {

--- a/src/main/java/com/likelion/RePlay/domain/info/service/InfoService.java
+++ b/src/main/java/com/likelion/RePlay/domain/info/service/InfoService.java
@@ -2,6 +2,7 @@ package com.likelion.RePlay.domain.info.service;
 
 
 import com.likelion.RePlay.domain.info.web.dto.InfoCreateDto;
+import com.likelion.RePlay.domain.info.web.dto.InfoModifyDto;
 import com.likelion.RePlay.global.response.CustomAPIResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.multipart.MultipartFile;
@@ -11,4 +12,10 @@ import java.util.List;
 public interface InfoService {
     // 관리자가 생생정보터에 글 작성
     ResponseEntity<CustomAPIResponse<?>> createInfo(InfoCreateDto.InfoCreateRequest infoCreateRequest, List<MultipartFile> images);
+
+    // 관리자가 생생정보터 게시글 수정
+    ResponseEntity<CustomAPIResponse<?>> modifyInfo(InfoModifyDto.InfoModifyRequest infoModifyRequest, List<MultipartFile> images);
+
+    // 관리자가 생생정보터 게시글 삭제 -> 보류
+    ResponseEntity<CustomAPIResponse<?>> deleteInfo(Long infoId);
 }

--- a/src/main/java/com/likelion/RePlay/domain/info/service/InfoServiceImpl.java
+++ b/src/main/java/com/likelion/RePlay/domain/info/service/InfoServiceImpl.java
@@ -3,6 +3,7 @@ package com.likelion.RePlay.domain.info.service;
 import com.likelion.RePlay.domain.info.entity.Info;
 import com.likelion.RePlay.domain.info.repository.InfoRepository;
 import com.likelion.RePlay.domain.info.web.dto.InfoCreateDto;
+import com.likelion.RePlay.domain.info.web.dto.InfoModifyDto;
 import com.likelion.RePlay.domain.user.entity.User;
 import com.likelion.RePlay.domain.user.repository.UserRepository;
 import com.likelion.RePlay.global.enums.RoleName;
@@ -29,6 +30,7 @@ public class InfoServiceImpl implements InfoService {
     public ResponseEntity<CustomAPIResponse<?>> createInfo(InfoCreateDto.InfoCreateRequest infoCreateRequest, List<MultipartFile> images) {
         Optional<User> isAdmin = userRepository.findByPhoneId(infoCreateRequest.getWriter());
 
+        // 사용자가 존쟂하지 않거나 관리자가 아니라면 작성 권한 없음
         if (isAdmin.isEmpty() || isAdmin.get().getUserRoles().stream()
                 .noneMatch(userRole -> userRole.getRole().getRoleName() == RoleName.ROLE_ADMIN)) {
             CustomAPIResponse<Object> failResponse = CustomAPIResponse
@@ -50,5 +52,49 @@ public class InfoServiceImpl implements InfoService {
 
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(CustomAPIResponse.createSuccess(HttpStatus.CREATED.value(), createInfo, "생생정보터에 글이 성공적으로 업로드되었습니다."));
+    }
+
+    @Override
+    public ResponseEntity<CustomAPIResponse<?>> modifyInfo(InfoModifyDto.InfoModifyRequest infoModifyRequest, List<MultipartFile> images) {
+        // 수정할 글이 존재하지 않는다면 수정할 수 없음
+        Optional<Info> optionalInfo = infoRepository.findById(infoModifyRequest.getInfoId());
+        if (optionalInfo.isEmpty()) {
+            CustomAPIResponse<Object> failResponse = CustomAPIResponse
+                    .createFailWithout(HttpStatus.NOT_FOUND.value(), "해당 글을 찾을 수 없습니다.");
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(failResponse);
+        }
+
+        // 존재하지 않는 사용자거나 관리자가 아니라면 수정 권함 없음
+        Optional<User> isAdmin = userRepository.findByPhoneId(infoModifyRequest.getWriter());
+        if (isAdmin.isEmpty() || isAdmin.get().getUserRoles().stream()
+                .noneMatch(userRole -> userRole.getRole().getRoleName() == RoleName.ROLE_ADMIN)) {
+            CustomAPIResponse<Object> failResponse = CustomAPIResponse
+                    .createFailWithout(HttpStatus.FORBIDDEN.value(), "글 수정 권한이 없습니다.");
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(failResponse);
+        }
+
+        Info info = optionalInfo.get();
+        info.setTitle(infoModifyRequest.getTitle());
+        info.setContent(infoModifyRequest.getContent());
+        info.setInfoNum(infoModifyRequest.getInfoNum());
+
+        infoRepository.save(info);
+
+        if (images != null && !images.isEmpty()) {
+            infoImageService.uploadImages(info, images);
+        }
+
+        InfoModifyDto.ModifyInfo modifyInfo = InfoModifyDto.ModifyInfo.builder()
+                .updatedAt(info.getUpdatedAt())
+                .build();
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(CustomAPIResponse.createSuccess(HttpStatus.OK.value(), modifyInfo, "생생정보글이 성공적으로 수정되었습니다."));
+    }
+
+    @Override
+    public ResponseEntity<CustomAPIResponse<?>> deleteInfo(Long infoId) {
+        // 보류
+        return null;
     }
 }

--- a/src/main/java/com/likelion/RePlay/domain/info/web/controller/InfoController.java
+++ b/src/main/java/com/likelion/RePlay/domain/info/web/controller/InfoController.java
@@ -2,6 +2,7 @@ package com.likelion.RePlay.domain.info.web;
 
 import com.likelion.RePlay.domain.info.service.InfoService;
 import com.likelion.RePlay.domain.info.web.dto.InfoCreateDto;
+import com.likelion.RePlay.domain.info.web.dto.InfoModifyDto;
 import com.likelion.RePlay.global.response.CustomAPIResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -21,5 +22,12 @@ public class InfoController {
             @RequestPart("infoCreateRequest") InfoCreateDto.InfoCreateRequest infoCreateRequest,
             @RequestPart("images") List<MultipartFile> images) {
         return infoService.createInfo(infoCreateRequest, images);
+    }
+
+    @PostMapping("/modifyInfo")
+    public ResponseEntity<CustomAPIResponse<?>> modifyInfo(
+            @RequestPart("infoModifyRequest") InfoModifyDto.InfoModifyRequest infoModifyRequest,
+            @RequestPart("images") List<MultipartFile> images){
+        return infoService.modifyInfo(infoModifyRequest, images);
     }
 }

--- a/src/main/java/com/likelion/RePlay/domain/info/web/dto/InfoModifyDto.java
+++ b/src/main/java/com/likelion/RePlay/domain/info/web/dto/InfoModifyDto.java
@@ -1,0 +1,55 @@
+package com.likelion.RePlay.domain.info.web.dto;
+
+import com.likelion.RePlay.domain.info.entity.Info;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+public class InfoModifyDto {
+    @Getter
+    @Setter
+    @Builder
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor
+    public static class InfoModifyRequest {
+        @NotNull(message="권한을 입력해주세요.")
+        private String roleName; //권한
+
+        @NotNull(message = "ID를 입력해주세요.")
+        private Long infoId; // 수정할 글의 ID
+
+        @NotEmpty(message = "작성자 이름을 입력해주세요.")
+        private String writer; // 작성자 (관리자 이름)
+
+        @NotBlank(message = "제목을 입력해주세요.")
+        private String title; // 수정할 제목
+
+        @NotBlank(message = "내용을 입력해주세요.")
+        private String content; // 수정할 내용
+
+        @NotNull(message="몇 호인지 입력해주세요.")
+        private Long infoNum; //수정할 생생정보터 호 수
+
+        public Info toEntity(){
+            return Info.builder()
+                    .title(title)
+                    .content(content)
+                    .infoNum(infoNum)
+                    .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class ModifyInfo {
+        private LocalDateTime updatedAt;
+
+        public ModifyInfo(LocalDateTime updatedAt) {
+            this.updatedAt = updatedAt;
+        }
+    }
+}


### PR DESCRIPTION
## 📄 생생정보터 게시글 수정 API

## 📖 설명
관리자는 생생정보터 게시글을 수정할 수 있다.(제목, 내용, 사진, 호수)

## 🔍 관련 이슈
- #40

## ✅ 체크리스트
- [ ] 코드가 컴파일 및 빌드됨
- [ ] 모든 테스트가 통과함
- [ ] 관련 문서가 업데이트됨
- [ ] 코드 리뷰가 수행됨