### PR TITLE
✨ FEAT. 배움터 모든 게시글 조회 API

### DIFF
--- a/src/main/java/com/likelion/RePlay/domain/learning/service/LearningService.java
+++ b/src/main/java/com/likelion/RePlay/domain/learning/service/LearningService.java
@@ -6,4 +6,6 @@ import org.springframework.http.ResponseEntity;
 
 public interface LearningService {
     ResponseEntity<CustomAPIResponse<?>> writePost(LearningWriteRequestDTO learningWriteRequestDTO);
+
+    ResponseEntity<CustomAPIResponse<?>> getAllPosts();
 }

--- a/src/main/java/com/likelion/RePlay/domain/learning/service/LearningServiceImpl.java
+++ b/src/main/java/com/likelion/RePlay/domain/learning/service/LearningServiceImpl.java
@@ -3,6 +3,7 @@ package com.likelion.RePlay.domain.learning.service;
 import com.likelion.RePlay.domain.learning.entity.Learning;
 import com.likelion.RePlay.domain.learning.repository.LearningApplyRepository;
 import com.likelion.RePlay.domain.learning.repository.LearningRepository;
+import com.likelion.RePlay.domain.learning.web.dto.LearningListDTO;
 import com.likelion.RePlay.domain.learning.web.dto.LearningWriteRequestDTO;
 import com.likelion.RePlay.domain.user.entity.User;
 import com.likelion.RePlay.domain.user.repository.UserRepository;
@@ -21,7 +22,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 import java.util.Optional;
 
 @Slf4j
@@ -79,5 +82,29 @@ public class LearningServiceImpl implements LearningService{
         return ResponseEntity.status(201)
                 .body(CustomAPIResponse.createSuccess(201, null, "게시글을 성공적으로 작성하였습니다."));
 
+    }
+
+    @Override
+    public ResponseEntity<CustomAPIResponse<?>> getAllPosts() {
+
+        List<Learning> learnings = learningRepository.findAll();
+
+        List<LearningListDTO.LearningResponse> learningResponses = new ArrayList<>();
+
+        for (Learning learning : learnings) {
+            learningResponses.add(LearningListDTO.LearningResponse.builder()
+                    .category(learning.getCategory())
+                    .title(learning.getTitle())
+                    .state(learning.getState())
+                    .district(learning.getDistrict())
+                    .date(learning.getDate())
+                    .totalCount(learning.getTotalCount())
+                    .recruitmentCount(learning.getRecruitmentCount())
+                    .imageUrl(learning.getImageUrl())
+                    .build());
+        }
+
+        return ResponseEntity.status(200)
+                .body(CustomAPIResponse.createSuccess(200, learningResponses, "게시글 목록을 성공적으로 불러왔습니다."));
     }
 }

--- a/src/main/java/com/likelion/RePlay/domain/learning/web/controller/LearningController.java
+++ b/src/main/java/com/likelion/RePlay/domain/learning/web/controller/LearningController.java
@@ -6,10 +6,7 @@ import com.likelion.RePlay.global.response.CustomAPIResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/learning")
@@ -22,6 +19,11 @@ public class LearningController {
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     private ResponseEntity<CustomAPIResponse<?>> writePost(@RequestBody LearningWriteRequestDTO learningWriteRequestDTO) {
         return learningService.writePost(learningWriteRequestDTO);
+    }
+
+    @GetMapping("/")
+    private ResponseEntity<CustomAPIResponse<?>> getAllPosts() {
+        return learningService.getAllPosts();
     }
 
 }

--- a/src/main/java/com/likelion/RePlay/domain/learning/web/dto/LearningListDTO.java
+++ b/src/main/java/com/likelion/RePlay/domain/learning/web/dto/LearningListDTO.java
@@ -1,0 +1,46 @@
+package com.likelion.RePlay.domain.learning.web.dto;
+
+
+import com.likelion.RePlay.global.enums.Category;
+import com.likelion.RePlay.global.enums.District;
+import com.likelion.RePlay.global.enums.State;
+import lombok.*;
+
+import java.util.Date;
+import java.util.List;
+
+public class LearningListDTO {
+
+    @Getter
+    @Setter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class LearningResponse {
+        private String nickname;
+        private String introduce;
+        private Category category;
+        private String title;
+        private String content;
+        private String locate;
+        private State state;
+        private District district;
+        private Date date;
+        private Long totalCount;
+        private Long recruitmentCount;
+        private Long cost;
+        private String costDescription;
+        private String imageUrl;
+    }
+
+    @Getter @Setter
+    @Builder
+    @NoArgsConstructor
+    public static class SearchLearnings {
+        private List<LearningResponse> learnings;
+
+        public SearchLearnings(List<LearningResponse> learnings) {
+            this.learnings = learnings;
+        }
+    }
+}

--- a/src/main/java/com/likelion/RePlay/global/security/SecurityConfig.java
+++ b/src/main/java/com/likelion/RePlay/global/security/SecurityConfig.java
@@ -31,6 +31,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests((authorize) -> authorize
                         .requestMatchers("/api/user/signUp", "/api/user/login").permitAll()
                         .requestMatchers("/api/playing/**").permitAll()
+                        .requestMatchers("/api/learning/**").permitAll()
                         .requestMatchers("/api/info/**").permitAll()
                         .anyRequest().hasAnyAuthority("ROLE_ADMIN")
                 )


### PR DESCRIPTION
## 📄 제목
배움터 모든 게시글 조회 API 작성

## 📖 설명
배움터의 모든 게시글을 조회할 수 있다.

## 🔍 관련 이슈
- 관련 이슈: #42 

## 🛠️ 변경 사항
구현하거나 수정한 주요 내용을 나열해주세요.
- [x] LearningController와 LearningService를 기능에 맞게 작성
- [x] 모든 게시글 정보를 Response Body에 담아 전달
- [x] SecurityConfig 경로에 해당 API 추가

## ✅ 체크리스트
PR을 제출하기 전에 완료해야 할 항목들을 나열해주세요.
- [x] 코드가 컴파일 및 빌드됨
- [x] 모든 테스트가 통과함
- [x] 관련 문서가 업데이트됨
- [x] 코드 리뷰가 수행됨
