### PR TITLE
✨ FEAT. 배움터 특정 게시글 조회 API

### DIFF
--- a/src/main/java/com/likelion/RePlay/domain/learning/service/LearningService.java
+++ b/src/main/java/com/likelion/RePlay/domain/learning/service/LearningService.java
@@ -8,4 +8,6 @@ public interface LearningService {
     ResponseEntity<CustomAPIResponse<?>> writePost(LearningWriteRequestDTO learningWriteRequestDTO);
 
     ResponseEntity<CustomAPIResponse<?>> getAllPosts();
+
+    ResponseEntity<CustomAPIResponse<?>> getPost(Long learningId);
 }

--- a/src/main/java/com/likelion/RePlay/domain/learning/service/LearningServiceImpl.java
+++ b/src/main/java/com/likelion/RePlay/domain/learning/service/LearningServiceImpl.java
@@ -107,4 +107,37 @@ public class LearningServiceImpl implements LearningService{
         return ResponseEntity.status(200)
                 .body(CustomAPIResponse.createSuccess(200, learningResponses, "게시글 목록을 성공적으로 불러왔습니다."));
     }
+
+    @Override
+    public ResponseEntity<CustomAPIResponse<?>> getPost(Long learningId) {
+
+        Optional<Learning> findLearning = learningRepository.findById(learningId);
+
+        if (findLearning.isEmpty()) {
+            return ResponseEntity.status(404)
+                    .body(CustomAPIResponse.createFailWithout(404, "존재하지 않는 게시글입니다."));
+        }
+
+        User user = findLearning.get().getUser();
+
+        LearningListDTO.LearningResponse  learningResponse = LearningListDTO.LearningResponse.builder()
+                .nickname(user.getNickname())
+                .introduce(user.getIntroduce())
+                .category(findLearning.get().getCategory())
+                .title(findLearning.get().getTitle())
+                .date(findLearning.get().getDate())
+                .locate(findLearning.get().getLocate())
+                .state(findLearning.get().getState())
+                .district(findLearning.get().getDistrict())
+                .totalCount(findLearning.get().getTotalCount())
+                .recruitmentCount(findLearning.get().getRecruitmentCount())
+                .content(findLearning.get().getContent())
+                .imageUrl(findLearning.get().getImageUrl())
+                .build();
+
+        return ResponseEntity.status(200)
+                .body(CustomAPIResponse.createSuccess(200, learningResponse, "특정 게시글을 성공적으로 불러왔습니다."));
+    }
+
+
 }

--- a/src/main/java/com/likelion/RePlay/domain/learning/web/controller/LearningController.java
+++ b/src/main/java/com/likelion/RePlay/domain/learning/web/controller/LearningController.java
@@ -26,4 +26,9 @@ public class LearningController {
         return learningService.getAllPosts();
     }
 
+    @GetMapping("/{learningId}")
+    private ResponseEntity<CustomAPIResponse<?>> getPost(@PathVariable Long learningId) {
+        return learningService.getPost(learningId);
+    }
+
 }

--- a/src/main/java/com/likelion/RePlay/domain/playing/service/PlayingServiceImpl.java
+++ b/src/main/java/com/likelion/RePlay/domain/playing/service/PlayingServiceImpl.java
@@ -122,12 +122,13 @@ public class PlayingServiceImpl implements PlayingService {
     public ResponseEntity<CustomAPIResponse<?>> getPost(Long playingId) {
 
         Optional<Playing> findPlaying = playingRepository.findById(playingId);
-        User user = findPlaying.get().getUser();
 
         if (findPlaying.isEmpty()) {
             return ResponseEntity.status(404)
                     .body(CustomAPIResponse.createFailWithout(404, "존재하지 않는 게시글입니다."));
         }
+
+        User user = findPlaying.get().getUser();
 
         PlayingListDTO.PlayingResponse playingResponse = PlayingListDTO.PlayingResponse.builder()
                 .nickname(user.getNickname())


### PR DESCRIPTION
## 📄 제목
배움터 특정 게시글 조회 API 작성 

## 📖 설명
배움터의 특정 게시글을 조회할 수 있다.

## 🔍 관련 이슈
- 관련 이슈: #46 

## 🛠️ 변경 사항
구현하거나 수정한 주요 내용을 나열해주세요.
- [x] LearningController와 LearningService를 기능에 맞게 작성
- [x] 해당 게시글 정보를 Response Body에 담아 전달

## ✅ 체크리스트
PR을 제출하기 전에 완료해야 할 항목들을 나열해주세요.
- [x] 코드가 컴파일 및 빌드됨
- [x] 모든 테스트가 통과함
- [x] 관련 문서가 업데이트됨
- [x] 코드 리뷰가 수행됨
