### PR TITLE
✨ FEAT. 배움터 게시글 참가 신청 API

### DIFF
--- a/src/main/java/com/likelion/RePlay/domain/learning/entity/Learning.java
+++ b/src/main/java/com/likelion/RePlay/domain/learning/entity/Learning.java
@@ -84,4 +84,15 @@ public class Learning extends BaseEntity {
     @OneToMany(mappedBy = "learning", cascade = CascadeType.ALL, orphanRemoval = true)
     @JsonManagedReference
     private List<LearningApply> learningApplies;
+
+
+    // 연관관계 편의 메서드
+    public void changeIsRecruit(IsRecruit isRecruit) {
+        this.isRecruit = isRecruit;
+    }
+
+    public void changeRecruitmentCount(Long recruitmentCount) {
+        this.recruitmentCount = recruitmentCount;
+    }
+
 }

--- a/src/main/java/com/likelion/RePlay/domain/learning/service/LearningService.java
+++ b/src/main/java/com/likelion/RePlay/domain/learning/service/LearningService.java
@@ -1,5 +1,6 @@
 package com.likelion.RePlay.domain.learning.service;
 
+import com.likelion.RePlay.domain.learning.web.dto.LearningApplyRequestDTO;
 import com.likelion.RePlay.domain.learning.web.dto.LearningFilteringDTO;
 import com.likelion.RePlay.domain.learning.web.dto.LearningWriteRequestDTO;
 import com.likelion.RePlay.global.response.CustomAPIResponse;
@@ -13,4 +14,6 @@ public interface LearningService {
     ResponseEntity<CustomAPIResponse<?>> getPost(Long learningId);
 
     ResponseEntity<CustomAPIResponse<?>> filtering(LearningFilteringDTO learningFilteringDTO);
+
+    ResponseEntity<CustomAPIResponse<?>> recruitLearning(Long learningId, LearningApplyRequestDTO learningApplyRequestDTO);
 }

--- a/src/main/java/com/likelion/RePlay/domain/learning/web/controller/LearningController.java
+++ b/src/main/java/com/likelion/RePlay/domain/learning/web/controller/LearningController.java
@@ -1,6 +1,7 @@
 package com.likelion.RePlay.domain.learning.web.controller;
 
 import com.likelion.RePlay.domain.learning.service.LearningService;
+import com.likelion.RePlay.domain.learning.web.dto.LearningApplyRequestDTO;
 import com.likelion.RePlay.domain.learning.web.dto.LearningFilteringDTO;
 import com.likelion.RePlay.domain.learning.web.dto.LearningWriteRequestDTO;
 import com.likelion.RePlay.global.response.CustomAPIResponse;
@@ -37,4 +38,8 @@ public class LearningController {
         return learningService.filtering(learningFilteringDTO);
     }
 
+    @PostMapping("/{learningId}")
+    private ResponseEntity<CustomAPIResponse<?>> recruitLearning(@PathVariable Long learningId, @RequestBody LearningApplyRequestDTO learningApplyRequestDTO) {
+        return learningService.recruitLearning(learningId, learningApplyRequestDTO);
+    }
 }

--- a/src/main/java/com/likelion/RePlay/domain/learning/web/dto/LearningApplyRequestDTO.java
+++ b/src/main/java/com/likelion/RePlay/domain/learning/web/dto/LearningApplyRequestDTO.java
@@ -1,0 +1,12 @@
+package com.likelion.RePlay.domain.learning.web.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LearningApplyRequestDTO {
+    private String phoneId;
+}


### PR DESCRIPTION
## 📄 제목
배움터 참가 신청 API

## 📖 설명
배움터의 게시글에서 신청하기 버튼을 누르면 모집중 여부, 모집인원 수에 따라 신청이 완료되는 API

## 🔍 관련 이슈
- 관련 이슈: #50 

## 🛠️ 변경 사항
- [x] LearningController, LearningServiceImpl에 관련 코드 추가
- [x] LearningApplyRepository 작성
- [x] Learning에 사용자 편의 메서드 추가

## ✅ 체크리스트
PR을 제출하기 전에 완료해야 할 항목들을 나열해주세요.
- [x] 코드가 컴파일 및 빌드됨
- [x] 모든 테스트가 통과함
- [x] 관련 문서가 업데이트됨
- [x] 코드 리뷰가 수행됨