### PR TITLE
✨ FEAT. 배움터 참가 신청 취소 API

### DIFF
--- a/src/main/java/com/likelion/RePlay/domain/learning/service/LearningService.java
+++ b/src/main/java/com/likelion/RePlay/domain/learning/service/LearningService.java
@@ -16,4 +16,6 @@ public interface LearningService {
     ResponseEntity<CustomAPIResponse<?>> filtering(LearningFilteringDTO learningFilteringDTO);
 
     ResponseEntity<CustomAPIResponse<?>> recruitLearning(Long learningId, LearningApplyRequestDTO learningApplyRequestDTO);
+
+    ResponseEntity<CustomAPIResponse<?>> cancelLearning(Long learningId, LearningApplyRequestDTO learningApplyRequestDTO);
 }

--- a/src/main/java/com/likelion/RePlay/domain/learning/web/controller/LearningController.java
+++ b/src/main/java/com/likelion/RePlay/domain/learning/web/controller/LearningController.java
@@ -42,4 +42,9 @@ public class LearningController {
     private ResponseEntity<CustomAPIResponse<?>> recruitLearning(@PathVariable Long learningId, @RequestBody LearningApplyRequestDTO learningApplyRequestDTO) {
         return learningService.recruitLearning(learningId, learningApplyRequestDTO);
     }
+
+    @DeleteMapping("/{learningId}")
+    private ResponseEntity<CustomAPIResponse<?>> cancelLearning(@PathVariable Long learningId, @RequestBody LearningApplyRequestDTO learningApplyRequestDTO) {
+        return learningService.cancelLearning(learningId, learningApplyRequestDTO);
+    }
 }


### PR DESCRIPTION
## 📄 제목
배움터 참가 신청 취소 API

## 📖 설명
신청한 게시글에 대해 참가 신청을 취소할 수 있다.

## 🔍 관련 이슈
- 관련 이슈: #52 

## 🛠️ 변경 사항
구현하거나 수정한 주요 내용을 나열해주세요.
- [x] LearningServiceImpl, LearningController 작성

## ✅ 체크리스트
- [x] 코드가 컴파일 및 빌드됨
- [x] 모든 테스트가 통과함
- [x] 관련 문서가 업데이트됨
- [x] 코드 리뷰가 수행됨
