### PR TITLE
✨ FEAT. 놀이터 게시글 스크랩 취소 API

### DIFF
--- a/src/main/java/com/likelion/RePlay/domain/playing/service/PlayingService.java
+++ b/src/main/java/com/likelion/RePlay/domain/playing/service/PlayingService.java
@@ -21,4 +21,6 @@ public interface PlayingService {
     ResponseEntity<CustomAPIResponse<?>> cancelPlaying(Long playingId, PlayingApplyScrapRequestDTO playingApplyScrapRequestDTO);
 
     ResponseEntity<CustomAPIResponse<?>> scrapPlaying(Long playingId, PlayingApplyScrapRequestDTO playingApplyScrapRequestDTO);
+
+    ResponseEntity<CustomAPIResponse<?>> cancelScrap(Long playingId, PlayingApplyScrapRequestDTO playingApplyScrapRequestDTO);
 }

--- a/src/main/java/com/likelion/RePlay/domain/playing/service/PlayingServiceImpl.java
+++ b/src/main/java/com/likelion/RePlay/domain/playing/service/PlayingServiceImpl.java
@@ -400,4 +400,39 @@ public class PlayingServiceImpl implements PlayingService {
         }
 
     }
+
+    @Override
+    public ResponseEntity<CustomAPIResponse<?>> cancelScrap(Long playingId, PlayingApplyScrapRequestDTO playingApplyScrapRequestDTO) {
+
+        String phoneId = playingApplyScrapRequestDTO.getPhoneId();
+
+        // 놀이터 게시글이 DB에 존재하는가?
+        Optional<Playing> findPlaying = playingRepository.findById(playingId);
+        // 존재하는 사용자인가?
+        Optional<User> findUser = userRepository.findByPhoneId(phoneId);
+
+        // 존재하지 않는다면 오류 반환
+        if (findPlaying.isEmpty()) {
+            return ResponseEntity.status(404)
+                    .body(CustomAPIResponse.createFailWithout(404, "존재하지 않는 게시글입니다."));
+        } else if (findUser.isEmpty()) {
+            return ResponseEntity.status(404)
+                    .body(CustomAPIResponse.createFailWithout(404, "존재하지 않는 유저입니다."));
+        }
+
+        Optional<PlayingScrap> findPlayingScrap = playingScrapRepository.findByUserPhoneId(phoneId);
+
+        // 스크랩한 않은 활동일 경우 취소한다.
+        if (findPlayingScrap.isPresent()) {
+            playingScrapRepository.delete(findPlayingScrap.get());
+
+            return ResponseEntity.status(200)
+                    .body(CustomAPIResponse.createSuccess(200, null, "스크랩이 취소되었습니다."));
+        }else {
+
+            return ResponseEntity.status(400)
+                    .body(CustomAPIResponse.createFailWithout(400,  "스크랩하지 않은 게시글입니다."));
+        }
+        
+    }
 }

--- a/src/main/java/com/likelion/RePlay/domain/playing/web/controller/PlayingController.java
+++ b/src/main/java/com/likelion/RePlay/domain/playing/web/controller/PlayingController.java
@@ -50,4 +50,9 @@ public class PlayingController {
     private ResponseEntity<CustomAPIResponse<?>> scrapPlaying(@PathVariable Long playingId, @RequestBody PlayingApplyScrapRequestDTO playingApplyScrapRequestDTO) {
         return playingService.scrapPlaying(playingId, playingApplyScrapRequestDTO);
     }
+
+    @DeleteMapping("/{playingId}/scrap")
+    private ResponseEntity<CustomAPIResponse<?>> cancelScrap(@PathVariable Long playingId, @RequestBody PlayingApplyScrapRequestDTO playingApplyScrapRequestDTO) {
+        return playingService.cancelScrap(playingId, playingApplyScrapRequestDTO);
+    }
 }


### PR DESCRIPTION
## 📄 제목
FEAT. 놀이터 게시글 스크랩 취소 API

## 📖 설명
저장한 게시글을 취소한다.

## 🔍 관련 이슈
- 관련 이슈: #55 

## 🛠️ 변경 사항
- [x] PlayingServiceImpl 및 PlayingController 기능에 맞게 작성

## ✅ 체크리스트
- [x] 코드가 컴파일 및 빌드됨
- [x] 모든 테스트가 통과함
- [x] 관련 문서가 업데이트됨
- [x] 코드 리뷰가 수행됨

