### PR TITLE
✨ FEAT. 배움터 게시글 스크랩 API

### DIFF
--- a/src/main/java/com/likelion/RePlay/domain/learning/repository/LearningScrapRepository.java
+++ b/src/main/java/com/likelion/RePlay/domain/learning/repository/LearningScrapRepository.java
@@ -1,0 +1,11 @@
+package com.likelion.RePlay.domain.learning.repository;
+
+import com.likelion.RePlay.domain.learning.entity.LearningApply;
+import com.likelion.RePlay.domain.learning.entity.LearningScrap;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface LearningScrapRepository extends JpaRepository<LearningScrap, Long> {
+    Optional<LearningScrap> findByUserPhoneId(String phoneId);
+}

--- a/src/main/java/com/likelion/RePlay/domain/learning/service/LearningService.java
+++ b/src/main/java/com/likelion/RePlay/domain/learning/service/LearningService.java
@@ -1,13 +1,14 @@
 package com.likelion.RePlay.domain.learning.service;
 
-import com.likelion.RePlay.domain.learning.web.dto.LearningApplyRequestDTO;
+import com.likelion.RePlay.domain.learning.web.dto.LearningApplyScrapRequestDTO;
 import com.likelion.RePlay.domain.learning.web.dto.LearningFilteringDTO;
 import com.likelion.RePlay.domain.learning.web.dto.LearningWriteRequestDTO;
 import com.likelion.RePlay.global.response.CustomAPIResponse;
+import com.likelion.RePlay.global.security.MyUserDetailsService;
 import org.springframework.http.ResponseEntity;
 
 public interface LearningService {
-    ResponseEntity<CustomAPIResponse<?>> writePost(LearningWriteRequestDTO learningWriteRequestDTO);
+    ResponseEntity<CustomAPIResponse<?>> writePost(LearningWriteRequestDTO learningWriteRequestDTO, MyUserDetailsService.MyUserDetails userDetails);
 
     ResponseEntity<CustomAPIResponse<?>> getAllPosts();
 
@@ -15,7 +16,9 @@ public interface LearningService {
 
     ResponseEntity<CustomAPIResponse<?>> filtering(LearningFilteringDTO learningFilteringDTO);
 
-    ResponseEntity<CustomAPIResponse<?>> recruitLearning(Long learningId, LearningApplyRequestDTO learningApplyRequestDTO);
+    ResponseEntity<CustomAPIResponse<?>> recruitLearning(Long learningId, LearningApplyScrapRequestDTO learningApplyScrapRequestDTO);
 
-    ResponseEntity<CustomAPIResponse<?>> cancelLearning(Long learningId, LearningApplyRequestDTO learningApplyRequestDTO);
+    ResponseEntity<CustomAPIResponse<?>> cancelLearning(Long learningId, LearningApplyScrapRequestDTO learningApplyScrapRequestDTO);
+
+    ResponseEntity<CustomAPIResponse<?>> scrapLearning(Long learningId, LearningApplyScrapRequestDTO learningApplyScrapRequestDTO);
 }

--- a/src/main/java/com/likelion/RePlay/domain/learning/service/LearningServiceImpl.java
+++ b/src/main/java/com/likelion/RePlay/domain/learning/service/LearningServiceImpl.java
@@ -2,8 +2,10 @@ package com.likelion.RePlay.domain.learning.service;
 
 import com.likelion.RePlay.domain.learning.entity.Learning;
 import com.likelion.RePlay.domain.learning.entity.LearningApply;
+import com.likelion.RePlay.domain.learning.entity.LearningScrap;
 import com.likelion.RePlay.domain.learning.repository.LearningApplyRepository;
 import com.likelion.RePlay.domain.learning.repository.LearningRepository;
+import com.likelion.RePlay.domain.learning.repository.LearningScrapRepository;
 import com.likelion.RePlay.domain.learning.web.dto.LearningApplyScrapRequestDTO;
 import com.likelion.RePlay.domain.learning.web.dto.LearningFilteringDTO;
 import com.likelion.RePlay.domain.learning.web.dto.LearningListDTO;
@@ -35,6 +37,7 @@ public class LearningServiceImpl implements LearningService{
     private final UserRepository userRepository;
     private final LearningRepository learningRepository;
     private final LearningApplyRepository learningApplyRepository;
+    private final LearningScrapRepository learningScrapRepository;
 
     @Override
     public ResponseEntity<CustomAPIResponse<?>> writePost(LearningWriteRequestDTO learningWriteRequestDTO, MyUserDetailsService.MyUserDetails userDetails) {
@@ -324,9 +327,35 @@ public class LearningServiceImpl implements LearningService{
     @Override
     public ResponseEntity<CustomAPIResponse<?>> scrapLearning(Long learningId, LearningApplyScrapRequestDTO learningApplyScrapRequestDTO) {
 
+        String phoneId = learningApplyScrapRequestDTO.getPhoneId();
 
+        Optional<Learning> findLearning = learningRepository.findById(learningId);
+        Optional<User> findUser = userRepository.findByPhoneId(phoneId);
 
-        return null;
+        if (findLearning.isEmpty()) {
+            return ResponseEntity.status(404)
+                    .body(CustomAPIResponse.createFailWithout(404, "존재하지 않는 게시글입니다."));
+        } else if (findUser.isEmpty()) {
+            return ResponseEntity.status(404)
+                    .body(CustomAPIResponse.createFailWithout(404, "존재하지 않는 유저입니다."));
+        }
+
+        Optional<LearningScrap> findLearningScrap = learningScrapRepository.findByUserPhoneId(phoneId);
+
+        if (findLearningScrap.isEmpty()) {
+            LearningScrap newScrap = LearningScrap.builder()
+                    .learning(findLearning.get())
+                    .user(findUser.get())
+                    .build();
+
+            learningScrapRepository.save(newScrap);
+            return ResponseEntity.status(200)
+                    .body(CustomAPIResponse.createSuccess(200, null, "스크랩되었습니다."));
+        }else {
+
+            return ResponseEntity.status(400)
+                    .body(CustomAPIResponse.createFailWithout(400,  "이미 스크랩했습니다."));
+        }
     }
 
 

--- a/src/main/java/com/likelion/RePlay/domain/learning/service/LearningServiceImpl.java
+++ b/src/main/java/com/likelion/RePlay/domain/learning/service/LearningServiceImpl.java
@@ -4,26 +4,21 @@ import com.likelion.RePlay.domain.learning.entity.Learning;
 import com.likelion.RePlay.domain.learning.entity.LearningApply;
 import com.likelion.RePlay.domain.learning.repository.LearningApplyRepository;
 import com.likelion.RePlay.domain.learning.repository.LearningRepository;
-import com.likelion.RePlay.domain.learning.web.dto.LearningApplyRequestDTO;
+import com.likelion.RePlay.domain.learning.web.dto.LearningApplyScrapRequestDTO;
 import com.likelion.RePlay.domain.learning.web.dto.LearningFilteringDTO;
 import com.likelion.RePlay.domain.learning.web.dto.LearningListDTO;
 import com.likelion.RePlay.domain.learning.web.dto.LearningWriteRequestDTO;
-import com.likelion.RePlay.domain.playing.entity.Playing;
-import com.likelion.RePlay.domain.playing.entity.PlayingApply;
 import com.likelion.RePlay.domain.user.entity.User;
 import com.likelion.RePlay.domain.user.repository.UserRepository;
 import com.likelion.RePlay.global.enums.*;
 import com.likelion.RePlay.global.response.CustomAPIResponse;
+import com.likelion.RePlay.global.security.MyUserDetailsService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import javax.swing.text.html.Option;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.LocalDate;
@@ -42,9 +37,9 @@ public class LearningServiceImpl implements LearningService{
     private final LearningApplyRepository learningApplyRepository;
 
     @Override
-    public ResponseEntity<CustomAPIResponse<?>> writePost(LearningWriteRequestDTO learningWriteRequestDTO) {
+    public ResponseEntity<CustomAPIResponse<?>> writePost(LearningWriteRequestDTO learningWriteRequestDTO, MyUserDetailsService.MyUserDetails userDetails) {
 
-        Optional<User> isAdmin = userRepository.findByPhoneId(learningWriteRequestDTO.getPhoneId());
+        Optional<User> isAdmin = userRepository.findByPhoneId(userDetails.getPhoneId());
 
         // 관리자만 글을 작성할 수 있다.
         if (isAdmin.isEmpty() || isAdmin.get().getUserRoles().stream()
@@ -222,9 +217,9 @@ public class LearningServiceImpl implements LearningService{
     }
 
     @Override
-    public ResponseEntity<CustomAPIResponse<?>> recruitLearning(Long learningId, LearningApplyRequestDTO learningApplyRequestDTO) {
+    public ResponseEntity<CustomAPIResponse<?>> recruitLearning(Long learningId, LearningApplyScrapRequestDTO learningApplyScrapRequestDTO) {
 
-        String phoneId = learningApplyRequestDTO.getPhoneId();
+        String phoneId = learningApplyScrapRequestDTO.getPhoneId();
 
         Optional<Learning> findLearning = learningRepository.findById(learningId);
         Optional<User> findUser = userRepository.findByPhoneId(phoneId);
@@ -283,9 +278,9 @@ public class LearningServiceImpl implements LearningService{
     }
 
     @Override
-    public ResponseEntity<CustomAPIResponse<?>> cancelLearning(Long learningId, LearningApplyRequestDTO learningApplyRequestDTO) {
+    public ResponseEntity<CustomAPIResponse<?>> cancelLearning(Long learningId, LearningApplyScrapRequestDTO learningApplyScrapRequestDTO) {
 
-        String phoneId = learningApplyRequestDTO.getPhoneId();
+        String phoneId = learningApplyScrapRequestDTO.getPhoneId();
 
         // 놀이터 게시글이 DB에 존재하는가?
         Optional<Learning> findLearning = learningRepository.findById(learningId);
@@ -324,6 +319,14 @@ public class LearningServiceImpl implements LearningService{
         return ResponseEntity.status(200)
                 .body(CustomAPIResponse.createSuccess(200, null, "활동 신청이 취소되었습니다."));
 
+    }
+
+    @Override
+    public ResponseEntity<CustomAPIResponse<?>> scrapLearning(Long learningId, LearningApplyScrapRequestDTO learningApplyScrapRequestDTO) {
+
+
+
+        return null;
     }
 
 

--- a/src/main/java/com/likelion/RePlay/domain/learning/web/controller/LearningController.java
+++ b/src/main/java/com/likelion/RePlay/domain/learning/web/controller/LearningController.java
@@ -1,13 +1,15 @@
 package com.likelion.RePlay.domain.learning.web.controller;
 
 import com.likelion.RePlay.domain.learning.service.LearningService;
-import com.likelion.RePlay.domain.learning.web.dto.LearningApplyRequestDTO;
+import com.likelion.RePlay.domain.learning.web.dto.LearningApplyScrapRequestDTO;
 import com.likelion.RePlay.domain.learning.web.dto.LearningFilteringDTO;
 import com.likelion.RePlay.domain.learning.web.dto.LearningWriteRequestDTO;
 import com.likelion.RePlay.global.response.CustomAPIResponse;
+import com.likelion.RePlay.global.security.MyUserDetailsService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -19,8 +21,8 @@ public class LearningController {
 
     @PostMapping("/writePost")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
-    private ResponseEntity<CustomAPIResponse<?>> writePost(@RequestBody LearningWriteRequestDTO learningWriteRequestDTO) {
-        return learningService.writePost(learningWriteRequestDTO);
+    private ResponseEntity<CustomAPIResponse<?>> writePost(@RequestBody LearningWriteRequestDTO learningWriteRequestDTO, @AuthenticationPrincipal MyUserDetailsService.MyUserDetails userDetails) {
+        return learningService.writePost(learningWriteRequestDTO, userDetails);
     }
 
     @GetMapping("/")
@@ -39,12 +41,17 @@ public class LearningController {
     }
 
     @PostMapping("/{learningId}")
-    private ResponseEntity<CustomAPIResponse<?>> recruitLearning(@PathVariable Long learningId, @RequestBody LearningApplyRequestDTO learningApplyRequestDTO) {
-        return learningService.recruitLearning(learningId, learningApplyRequestDTO);
+    private ResponseEntity<CustomAPIResponse<?>> recruitLearning(@PathVariable Long learningId, @RequestBody LearningApplyScrapRequestDTO learningApplyScrapRequestDTO) {
+        return learningService.recruitLearning(learningId, learningApplyScrapRequestDTO);
     }
 
     @DeleteMapping("/{learningId}")
-    private ResponseEntity<CustomAPIResponse<?>> cancelLearning(@PathVariable Long learningId, @RequestBody LearningApplyRequestDTO learningApplyRequestDTO) {
-        return learningService.cancelLearning(learningId, learningApplyRequestDTO);
+    private ResponseEntity<CustomAPIResponse<?>> cancelLearning(@PathVariable Long learningId, @RequestBody LearningApplyScrapRequestDTO learningApplyScrapRequestDTO) {
+        return learningService.cancelLearning(learningId, learningApplyScrapRequestDTO);
+    }
+
+    @PostMapping("/{learningId}/scrap")
+    private ResponseEntity<CustomAPIResponse<?>> scrapLearning(@PathVariable Long learningId, @RequestBody LearningApplyScrapRequestDTO learningApplyScrapRequestDTO) {
+        return learningService.scrapLearning(learningId, learningApplyScrapRequestDTO);
     }
 }

--- a/src/main/java/com/likelion/RePlay/domain/learning/web/dto/LearningApplyScrapRequestDTO.java
+++ b/src/main/java/com/likelion/RePlay/domain/learning/web/dto/LearningApplyScrapRequestDTO.java
@@ -7,6 +7,6 @@ import lombok.*;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class LearningApplyRequestDTO {
+public class LearningApplyScrapRequestDTO {
     private String phoneId;
 }


### PR DESCRIPTION
## 📄 제목
FEAT. 배움터 게시글 스크랩 API

## 📖 설명
배움터 게시글을 스크랩할 수 있다.

## 🔍 관련 이슈
- 관련 이슈: #57 

## 🛠️ 변경 사항
- [x] LearningScrapRepository 생성
- [x] LearningServiceImpl, LearningController 수정
- [x] LearningApplyRequestDTO -> LearningApplyScrapDTO로 메서드명 변경
- [x] LearningController writePost 메서드에 관리자 접근 권한 부여

## ✅ 체크리스트
PR을 제출하기 전에 완료해야 할 항목들을 나열해주세요.
- [x] 코드가 컴파일 및 빌드됨
- [x] 모든 테스트가 통과함
- [x] 관련 문서가 업데이트됨
- [x] 코드 리뷰가 수행됨