### PR TITLE
✨ FEAT. 배움터 게시글 스크랩 취소 API

### DIFF
--- a/src/main/java/com/likelion/RePlay/domain/learning/service/LearningService.java
+++ b/src/main/java/com/likelion/RePlay/domain/learning/service/LearningService.java
@@ -21,4 +21,6 @@ public interface LearningService {
     ResponseEntity<CustomAPIResponse<?>> cancelLearning(Long learningId, LearningApplyScrapRequestDTO learningApplyScrapRequestDTO);
 
     ResponseEntity<CustomAPIResponse<?>> scrapLearning(Long learningId, LearningApplyScrapRequestDTO learningApplyScrapRequestDTO);
+
+    ResponseEntity<CustomAPIResponse<?>> cancelScrap(Long learningId, LearningApplyScrapRequestDTO learningApplyScrapRequestDTO);
 }

--- a/src/main/java/com/likelion/RePlay/domain/learning/service/LearningServiceImpl.java
+++ b/src/main/java/com/likelion/RePlay/domain/learning/service/LearningServiceImpl.java
@@ -358,5 +358,34 @@ public class LearningServiceImpl implements LearningService{
         }
     }
 
+    @Override
+    public ResponseEntity<CustomAPIResponse<?>> cancelScrap(Long learningId, LearningApplyScrapRequestDTO learningApplyScrapRequestDTO) {
+
+        String phoneId = learningApplyScrapRequestDTO.getPhoneId();
+
+        Optional<Learning> findLearning = learningRepository.findById(learningId);
+        Optional<User> findUser = userRepository.findByPhoneId(phoneId);
+
+        if (findLearning.isEmpty()) {
+            return ResponseEntity.status(404)
+                    .body(CustomAPIResponse.createFailWithout(404, "존재하지 않는 게시글입니다."));
+        } else if (findUser.isEmpty()) {
+            return ResponseEntity.status(404)
+                    .body(CustomAPIResponse.createFailWithout(404, "존재하지 않는 유저입니다."));
+        }
+
+        Optional<LearningScrap> findLearningScrap = learningScrapRepository.findByUserPhoneId(phoneId);
+
+        if (findLearningScrap.isPresent()) {
+            learningScrapRepository.delete(findLearningScrap.get());
+            return ResponseEntity.status(200)
+                    .body(CustomAPIResponse.createSuccess(200, null, "스크랩이 취소되었습니다."));
+        }else {
+
+            return ResponseEntity.status(400)
+                    .body(CustomAPIResponse.createFailWithout(400,  "스크랩하지 않은 게시글입니다."));
+        }
+    }
+
 
 }

--- a/src/main/java/com/likelion/RePlay/domain/learning/web/controller/LearningController.java
+++ b/src/main/java/com/likelion/RePlay/domain/learning/web/controller/LearningController.java
@@ -4,6 +4,7 @@ import com.likelion.RePlay.domain.learning.service.LearningService;
 import com.likelion.RePlay.domain.learning.web.dto.LearningApplyScrapRequestDTO;
 import com.likelion.RePlay.domain.learning.web.dto.LearningFilteringDTO;
 import com.likelion.RePlay.domain.learning.web.dto.LearningWriteRequestDTO;
+import com.likelion.RePlay.domain.playing.web.dto.PlayingApplyScrapRequestDTO;
 import com.likelion.RePlay.global.response.CustomAPIResponse;
 import com.likelion.RePlay.global.security.MyUserDetailsService;
 import lombok.RequiredArgsConstructor;
@@ -54,4 +55,10 @@ public class LearningController {
     private ResponseEntity<CustomAPIResponse<?>> scrapLearning(@PathVariable Long learningId, @RequestBody LearningApplyScrapRequestDTO learningApplyScrapRequestDTO) {
         return learningService.scrapLearning(learningId, learningApplyScrapRequestDTO);
     }
+
+    @DeleteMapping("/{learningId}/scrap")
+    private ResponseEntity<CustomAPIResponse<?>> cancelScrap(@PathVariable Long learningId, @RequestBody LearningApplyScrapRequestDTO learningApplyScrapRequestDTO) {
+        return learningService.cancelScrap(learningId, learningApplyScrapRequestDTO);
+    }
+
 }


### PR DESCRIPTION
## 📄 제목
배움터 게시글 스크랩 취소 API

## 📖 설명
저장한 게시글을 취소한다.

## 🔍 관련 이슈
- 관련 이슈: #58 

## 🛠️ 변경 사항
- [x] LearningServiceImpl 및 LearningController 기능에 맞게 작성

## ✅ 체크리스트
PR을 제출하기 전에 완료해야 할 항목들을 나열해주세요.
- [x] 코드가 컴파일 및 빌드됨
- [x] 모든 테스트가 통과함
- [x] 관련 문서가 업데이트됨
- [x] 코드 리뷰가 수행됨

