### PR TITLE
✨ FEAT. 배움터 게시글 수정 API 

### DIFF
--- a/src/main/java/com/likelion/RePlay/domain/learning/entity/Learning.java
+++ b/src/main/java/com/likelion/RePlay/domain/learning/entity/Learning.java
@@ -87,6 +87,34 @@ public class Learning extends BaseEntity {
 
 
     // 연관관계 편의 메서드
+    public void changeDate(Date date) {
+        this.date = date;
+    }
+
+    public void changeLocate(String locate) {
+        this.locate = locate;
+    }
+
+    public void changeCategory(Category category) {
+        this.category = category;
+    }
+
+    public void changeTitle(String title) {
+        this.title = title;
+    }
+
+    public void changeContent(String content) {
+        this.content = content;
+    }
+
+    public void changeImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
+
+    public void changeTotalCount(Long totalCount) {
+        this.totalCount = totalCount;
+    }
+
     public void changeIsRecruit(IsRecruit isRecruit) {
         this.isRecruit = isRecruit;
     }

--- a/src/main/java/com/likelion/RePlay/domain/learning/service/LearningService.java
+++ b/src/main/java/com/likelion/RePlay/domain/learning/service/LearningService.java
@@ -10,6 +10,8 @@ import org.springframework.http.ResponseEntity;
 public interface LearningService {
     ResponseEntity<CustomAPIResponse<?>> writePost(LearningWriteRequestDTO learningWriteRequestDTO, MyUserDetailsService.MyUserDetails userDetails);
 
+    ResponseEntity<CustomAPIResponse<?>> modifyPost(Long learningId, LearningWriteRequestDTO learningWriteRequestDTO, MyUserDetailsService.MyUserDetails userDetails);
+
     ResponseEntity<CustomAPIResponse<?>> getAllPosts();
 
     ResponseEntity<CustomAPIResponse<?>> getPost(Long learningId);
@@ -23,4 +25,5 @@ public interface LearningService {
     ResponseEntity<CustomAPIResponse<?>> scrapLearning(Long learningId, LearningApplyScrapRequestDTO learningApplyScrapRequestDTO);
 
     ResponseEntity<CustomAPIResponse<?>> cancelScrap(Long learningId, LearningApplyScrapRequestDTO learningApplyScrapRequestDTO);
-}
+
+    }

--- a/src/main/java/com/likelion/RePlay/domain/learning/web/controller/LearningController.java
+++ b/src/main/java/com/likelion/RePlay/domain/learning/web/controller/LearningController.java
@@ -26,6 +26,11 @@ public class LearningController {
         return learningService.writePost(learningWriteRequestDTO, userDetails);
     }
 
+    @PutMapping("/{learningId}")
+    private ResponseEntity<CustomAPIResponse<?>> modifyPost(@PathVariable Long learningId, @RequestBody LearningWriteRequestDTO learningWriteRequestDTO, @AuthenticationPrincipal MyUserDetailsService.MyUserDetails userDetails) {
+        return learningService.modifyPost(learningId, learningWriteRequestDTO, userDetails);
+    }
+
     @GetMapping("/")
     private ResponseEntity<CustomAPIResponse<?>> getAllPosts() {
         return learningService.getAllPosts();

--- a/src/main/java/com/likelion/RePlay/domain/learning/web/dto/LearningWriteRequestDTO.java
+++ b/src/main/java/com/likelion/RePlay/domain/learning/web/dto/LearningWriteRequestDTO.java
@@ -11,7 +11,7 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 public class LearningWriteRequestDTO {
-    private String phoneId;
+    //private String phoneId;
     private String title;
     private String date;
     private String locate; // 카카오맵으로 검색한 주소
@@ -20,9 +20,7 @@ public class LearningWriteRequestDTO {
     private State state;
     private District district;
     private Category category;
-    private String content; // 놀이 설명
+    private String content; // 배움 설명
     private Long totalCount;
-    private String cost; // 참가비용
-    private String costDescription; //참가비용 설명
     private String imageUrl;
 }


### PR DESCRIPTION
## 📄 제목
배움터 게시글 수정 API 

## 📖 설명
관리자만 배움터 게시글 수정이 가능하다.

## 🔍 관련 이슈
- 관련 이슈: #63 

## 🛠️ 변경 사항
구현하거나 수정한 주요 내용을 나열해주세요.
- [x] Learning 엔티티에 연관관계 편의 메서드 추가
- [x] LearningController. LearningServiceImpl 기능에 맞게 작성
- [x] DTO로 받아올 정보 수정

## ✅ 체크리스트
- [x] 코드가 컴파일 및 빌드됨
- [x] 모든 테스트가 통과함
- [x] 관련 문서가 업데이트됨
- [x] 코드 리뷰가 수행됨
