### PR TITLE
✨ FEAT. 내가 작성한 놀이터 게시글 조회 API

### DIFF
--- a/src/main/java/com/likelion/RePlay/domain/playing/repository/PlayingRepository.java
+++ b/src/main/java/com/likelion/RePlay/domain/playing/repository/PlayingRepository.java
@@ -2,7 +2,9 @@ package com.likelion.RePlay.domain.playing.repository;
 
 import com.likelion.RePlay.domain.playing.entity.Playing;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 
-public interface PlayingRepository extends JpaRepository<Playing, Long>, QuerydslPredicateExecutor<Playing> {
+import java.util.Optional;
+
+public interface PlayingRepository extends JpaRepository<Playing, Long> {
+
 }

--- a/src/main/java/com/likelion/RePlay/domain/playing/repository/PlayingRepository.java
+++ b/src/main/java/com/likelion/RePlay/domain/playing/repository/PlayingRepository.java
@@ -3,8 +3,9 @@ package com.likelion.RePlay.domain.playing.repository;
 import com.likelion.RePlay.domain.playing.entity.Playing;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface PlayingRepository extends JpaRepository<Playing, Long> {
-
+    List<Playing> findAllByUserPhoneId(String phoneId);
 }

--- a/src/main/java/com/likelion/RePlay/domain/playing/service/PlayingService.java
+++ b/src/main/java/com/likelion/RePlay/domain/playing/service/PlayingService.java
@@ -28,4 +28,5 @@ public interface PlayingService {
     ResponseEntity<CustomAPIResponse<?>> cancelScrap(Long playingId, PlayingApplyScrapRequestDTO playingApplyScrapRequestDTO, MyUserDetailsService.MyUserDetails userDetails);
 
 
+    ResponseEntity<CustomAPIResponse<?>> getMyPlayings(MyUserDetailsService.MyUserDetails userDetails);
 }

--- a/src/main/java/com/likelion/RePlay/domain/playing/service/PlayingService.java
+++ b/src/main/java/com/likelion/RePlay/domain/playing/service/PlayingService.java
@@ -4,13 +4,14 @@ import com.likelion.RePlay.domain.playing.web.dto.PlayingApplyScrapRequestDTO;
 import com.likelion.RePlay.domain.playing.web.dto.PlayingFilteringDTO;
 import com.likelion.RePlay.domain.playing.web.dto.PlayingWriteRequestDTO;
 import com.likelion.RePlay.global.response.CustomAPIResponse;
+import com.likelion.RePlay.global.security.MyUserDetailsService;
 import org.springframework.http.ResponseEntity;
 
 
 public interface PlayingService {
-    ResponseEntity<CustomAPIResponse<?>> writePost(PlayingWriteRequestDTO postWriteRequestDTO);
+    ResponseEntity<CustomAPIResponse<?>> writePost(PlayingWriteRequestDTO postWriteRequestDTO, MyUserDetailsService.MyUserDetails userDetails);
 
-    ResponseEntity<CustomAPIResponse<?>> modifyPost(Long playingId, PlayingWriteRequestDTO playingWriteRequestDTO);
+    ResponseEntity<CustomAPIResponse<?>> modifyPost(Long playingId, PlayingWriteRequestDTO playingWriteRequestDTO, MyUserDetailsService.MyUserDetails userDetails);
 
     ResponseEntity<CustomAPIResponse<?>> getAllPosts();
 
@@ -18,13 +19,13 @@ public interface PlayingService {
 
     ResponseEntity<CustomAPIResponse<?>> filtering(PlayingFilteringDTO playingFilteringDTO);
 
-    ResponseEntity<CustomAPIResponse<?>> recruitPlaying(Long playingId, PlayingApplyScrapRequestDTO playingApplyScrapRequestDTO);
+    ResponseEntity<CustomAPIResponse<?>> recruitPlaying(Long playingId, PlayingApplyScrapRequestDTO playingApplyScrapRequestDTO, MyUserDetailsService.MyUserDetails userDetails);
 
-    ResponseEntity<CustomAPIResponse<?>> cancelPlaying(Long playingId, PlayingApplyScrapRequestDTO playingApplyScrapRequestDTO);
+    ResponseEntity<CustomAPIResponse<?>> cancelPlaying(Long playingId, PlayingApplyScrapRequestDTO playingApplyScrapRequestDTO, MyUserDetailsService.MyUserDetails userDetails);
 
-    ResponseEntity<CustomAPIResponse<?>> scrapPlaying(Long playingId, PlayingApplyScrapRequestDTO playingApplyScrapRequestDTO);
+    ResponseEntity<CustomAPIResponse<?>> scrapPlaying(Long playingId, PlayingApplyScrapRequestDTO playingApplyScrapRequestDTO, MyUserDetailsService.MyUserDetails userDetails);
 
-    ResponseEntity<CustomAPIResponse<?>> cancelScrap(Long playingId, PlayingApplyScrapRequestDTO playingApplyScrapRequestDTO);
+    ResponseEntity<CustomAPIResponse<?>> cancelScrap(Long playingId, PlayingApplyScrapRequestDTO playingApplyScrapRequestDTO, MyUserDetailsService.MyUserDetails userDetails);
 
 
 }

--- a/src/main/java/com/likelion/RePlay/domain/playing/service/PlayingServiceImpl.java
+++ b/src/main/java/com/likelion/RePlay/domain/playing/service/PlayingServiceImpl.java
@@ -17,6 +17,7 @@ import com.likelion.RePlay.global.enums.IsCompleted;
 import com.likelion.RePlay.global.enums.IsRecruit;
 import com.likelion.RePlay.global.enums.State;
 import com.likelion.RePlay.global.response.CustomAPIResponse;
+import com.likelion.RePlay.global.security.MyUserDetailsService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -43,10 +44,10 @@ public class PlayingServiceImpl implements PlayingService {
     private final PlayingScrapRepository playingScrapRepository;
 
     @Override
-    public ResponseEntity<CustomAPIResponse<?>> writePost(PlayingWriteRequestDTO playingWriteRequestDTO) {
+    public ResponseEntity<CustomAPIResponse<?>> writePost(PlayingWriteRequestDTO playingWriteRequestDTO, MyUserDetailsService.MyUserDetails userDetails) {
 
         // 게시글 작성자가 DB에 존재하는가?
-        Optional<User> findUser = userRepository.findByPhoneId(playingWriteRequestDTO.getPhoneId());
+        Optional<User> findUser = userRepository.findByPhoneId(userDetails.getPhoneId());
 
         // 없다면 오류 반환
         if (findUser.isEmpty()) {
@@ -95,10 +96,10 @@ public class PlayingServiceImpl implements PlayingService {
     }
 
     @Override
-    public ResponseEntity<CustomAPIResponse<?>> modifyPost(Long playingId, PlayingWriteRequestDTO playingWriteRequestDTO) {
+    public ResponseEntity<CustomAPIResponse<?>> modifyPost(Long playingId, PlayingWriteRequestDTO playingWriteRequestDTO, MyUserDetailsService.MyUserDetails userDetails) {
 
         // 게시글 작성자가 DB에 존재하는가?
-        Optional<User> findUser = userRepository.findByPhoneId(playingWriteRequestDTO.getPhoneId());
+        Optional<User> findUser = userRepository.findByPhoneId(userDetails.getPhoneId());
         Optional<Playing> findPlaying = playingRepository.findById(playingId);
 
         Playing playing = findPlaying.get();
@@ -310,9 +311,9 @@ public class PlayingServiceImpl implements PlayingService {
     }
 
     @Override
-    public ResponseEntity<CustomAPIResponse<?>> recruitPlaying(Long playingId, PlayingApplyScrapRequestDTO playingApplyScrapRequestDTO) {
+    public ResponseEntity<CustomAPIResponse<?>> recruitPlaying(Long playingId, PlayingApplyScrapRequestDTO playingApplyScrapRequestDTO, MyUserDetailsService.MyUserDetails userDetails) {
 
-        String phoneId = playingApplyScrapRequestDTO.getPhoneId();
+        String phoneId = userDetails.getPhoneId();
 
         // 놀이터 게시글이 DB에 존재하는가?
         Optional<Playing> findPlaying = playingRepository.findById(playingId);
@@ -382,9 +383,9 @@ public class PlayingServiceImpl implements PlayingService {
     }
 
     @Override
-    public ResponseEntity<CustomAPIResponse<?>> cancelPlaying(Long playingId, PlayingApplyScrapRequestDTO playingApplyScrapRequestDTO) {
+    public ResponseEntity<CustomAPIResponse<?>> cancelPlaying(Long playingId, PlayingApplyScrapRequestDTO playingApplyScrapRequestDTO, MyUserDetailsService.MyUserDetails userDetails) {
 
-        String phoneId = playingApplyScrapRequestDTO.getPhoneId();
+        String phoneId = userDetails.getPhoneId();
 
         // 놀이터 게시글이 DB에 존재하는가?
         Optional<Playing> findPlaying = playingRepository.findById(playingId);
@@ -425,9 +426,9 @@ public class PlayingServiceImpl implements PlayingService {
     }
 
     @Override
-    public ResponseEntity<CustomAPIResponse<?>> scrapPlaying(Long playingId, PlayingApplyScrapRequestDTO playingApplyScrapRequestDTO) {
+    public ResponseEntity<CustomAPIResponse<?>> scrapPlaying(Long playingId, PlayingApplyScrapRequestDTO playingApplyScrapRequestDTO, MyUserDetailsService.MyUserDetails userDetails) {
 
-        String phoneId = playingApplyScrapRequestDTO.getPhoneId();
+        String phoneId = userDetails.getPhoneId();
 
         // 놀이터 게시글이 DB에 존재하는가?
         Optional<Playing> findPlaying = playingRepository.findById(playingId);
@@ -466,9 +467,9 @@ public class PlayingServiceImpl implements PlayingService {
     }
 
     @Override
-    public ResponseEntity<CustomAPIResponse<?>> cancelScrap(Long playingId, PlayingApplyScrapRequestDTO playingApplyScrapRequestDTO) {
+    public ResponseEntity<CustomAPIResponse<?>> cancelScrap(Long playingId, PlayingApplyScrapRequestDTO playingApplyScrapRequestDTO, MyUserDetailsService.MyUserDetails userDetails) {
 
-        String phoneId = playingApplyScrapRequestDTO.getPhoneId();
+        String phoneId = userDetails.getPhoneId();
 
         // 놀이터 게시글이 DB에 존재하는가?
         Optional<Playing> findPlaying = playingRepository.findById(playingId);

--- a/src/main/java/com/likelion/RePlay/domain/playing/service/PlayingServiceImpl.java
+++ b/src/main/java/com/likelion/RePlay/domain/playing/service/PlayingServiceImpl.java
@@ -46,14 +46,10 @@ public class PlayingServiceImpl implements PlayingService {
     @Override
     public ResponseEntity<CustomAPIResponse<?>> writePost(PlayingWriteRequestDTO playingWriteRequestDTO, MyUserDetailsService.MyUserDetails userDetails) {
 
-        // 게시글 작성자가 DB에 존재하는가?
-        Optional<User> findUser = userRepository.findByPhoneId(userDetails.getPhoneId());
-
-        // 없다면 오류 반환
-        if (findUser.isEmpty()) {
-            return ResponseEntity.status(404)
-                    .body(CustomAPIResponse.createFailWithout(404, "존재하지 않는 사용자입니다."));
-        }
+        // 인증된 사용자 정보에서 phoneId를 가져온다.
+        String phoneId = userDetails.getPhoneId();
+        User user = userRepository.findByPhoneId(phoneId)
+                .orElseThrow(() -> new IllegalStateException("존재하지 않는 사용자입니다."));
 
         String dateStr = playingWriteRequestDTO.getDate();
         SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy년 M월 d일 a h시 m분");
@@ -65,7 +61,6 @@ public class PlayingServiceImpl implements PlayingService {
         }
 
         // 존재한다면 게시글을 DB에 저장한다. 자기소개는 User 엔티티에 저장한다.
-        User user = findUser.get();
         user.changeIntroduce(playingWriteRequestDTO.getIntroduce());
         userRepository.save(user);
 
@@ -98,27 +93,24 @@ public class PlayingServiceImpl implements PlayingService {
     @Override
     public ResponseEntity<CustomAPIResponse<?>> modifyPost(Long playingId, PlayingWriteRequestDTO playingWriteRequestDTO, MyUserDetailsService.MyUserDetails userDetails) {
 
-        // 게시글 작성자가 DB에 존재하는가?
-        Optional<User> findUser = userRepository.findByPhoneId(userDetails.getPhoneId());
+        String phoneId = userDetails.getPhoneId();
+        User user = userRepository.findByPhoneId(phoneId)
+                .orElseThrow(() -> new IllegalStateException("존재하지 않는 사용자입니다."));
+
+        // 게시글 존재 여부 확인
         Optional<Playing> findPlaying = playingRepository.findById(playingId);
-
-        Playing playing = findPlaying.get();
-        User user = findUser.get();
-
-        // 없다면 오류 반환
-        if (findUser.isEmpty()) {
-            return ResponseEntity.status(404)
-                    .body(CustomAPIResponse.createFailWithout(404, "존재하지 않는 사용자입니다."));
-        } else if (findPlaying.isEmpty()) {
+        if (findPlaying.isEmpty()) {
             return ResponseEntity.status(404)
                     .body(CustomAPIResponse.createFailWithout(404, "존재하지 않는 게시글입니다."));
         }
 
-        if (playing.getUser().getPhoneId() != user.getPhoneId()) {
+        Playing playing = findPlaying.get();
+
+        // 사용자가 해당 게시글의 작성자인지 확인
+        if (!playing.getUser().getPhoneId().equals(phoneId)) {
             return ResponseEntity.status(403)
                     .body(CustomAPIResponse.createFailWithout(403, "본인의 글만 수정할 수 있습니다."));
         }
-
 
         String dateStr = playingWriteRequestDTO.getDate();
         SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy년 M월 d일 a h시 m분");
@@ -314,32 +306,31 @@ public class PlayingServiceImpl implements PlayingService {
     public ResponseEntity<CustomAPIResponse<?>> recruitPlaying(Long playingId, PlayingApplyScrapRequestDTO playingApplyScrapRequestDTO, MyUserDetailsService.MyUserDetails userDetails) {
 
         String phoneId = userDetails.getPhoneId();
+        User user = userRepository.findByPhoneId(phoneId)
+                .orElseThrow(() -> new IllegalStateException("존재하지 않는 사용자입니다."));
 
         // 놀이터 게시글이 DB에 존재하는가?
         Optional<Playing> findPlaying = playingRepository.findById(playingId);
-        // 존재하는 사용자인가?
-        Optional<User> findUser = userRepository.findByPhoneId(phoneId);
 
         // 존재하지 않는다면 오류 반환
         if (findPlaying.isEmpty()) {
             return ResponseEntity.status(404)
                     .body(CustomAPIResponse.createFailWithout(404, "존재하지 않는 게시글입니다."));
-        } else if (findUser.isEmpty()) {
-            return ResponseEntity.status(404)
-                    .body(CustomAPIResponse.createFailWithout(404, "존재하지 않는 유저입니다."));
         }
-        
+
+        Playing playing = findPlaying.get();
+
         // 게시글 작성자와 현재 작성자가 같다면 참가 신청 불가
-        if (findPlaying.get().getUser() == findUser.get()) {
+        if (playing.getUser().getPhoneId().equals(phoneId)) {
             return ResponseEntity.status(400)
                     .body(CustomAPIResponse.createFailWithout(400, "내가 올린 게시글에 참가할 수 없습니다."));
         }
 
         // 인원이 다 차거나 모집 완료된 활동일 경우 오류 반환
-        if (findPlaying.get().getIsRecruit() == IsRecruit.FALSE) {
+        if (playing.getIsRecruit() == IsRecruit.FALSE) {
             return ResponseEntity.status(400)
                     .body(CustomAPIResponse.createFailWithout(400, "인원이 마감되었습니다."));
-        } else if (findPlaying.get().getIsCompleted() == IsCompleted.TRUE) {
+        } else if (playing.getIsCompleted() == IsCompleted.TRUE) {
             return ResponseEntity.status(400)
                     .body(CustomAPIResponse.createFailWithout(400, "모집 완료된 활동입니다."));
         }
@@ -351,7 +342,7 @@ public class PlayingServiceImpl implements PlayingService {
         if (findPlayingApply.isEmpty()) {
             PlayingApply newApply = PlayingApply.builder()
                     .playing(findPlaying.get())
-                    .user(findUser.get())
+                    .user(user)
                     .build();
 
             playingApplyRepository.save(newApply);
@@ -362,20 +353,20 @@ public class PlayingServiceImpl implements PlayingService {
         }
 
         // 해당 게시글에 모집 인원을 추가한다.
-        findPlaying.get().changeRecruitmentCount(findPlaying.get().getRecruitmentCount() + 1);
+        playing.changeRecruitmentCount(playing.getRecruitmentCount() + 1);
 
         // 모집인원이 다 찼을 경우, 모집중 -> 모집완료로 바꾼다.
-        if (findPlaying.get().getRecruitmentCount() == findPlaying.get().getTotalCount()) {
-            findPlaying.get().changeIsRecruit(IsRecruit.FALSE);
+        if (playing.getRecruitmentCount() == playing.getTotalCount()) {
+            playing.changeIsRecruit(IsRecruit.FALSE);
         }
 
         PlayingListDTO.PlayingResponse playingResponse = PlayingListDTO.PlayingResponse.builder()
-                .category(findPlaying.get().getCategory())
-                .title(findPlaying.get().getTitle())
-                .date(findPlaying.get().getDate())
-                .locate(findPlaying.get().getLocate())
-                .cost(findPlaying.get().getCost())
-                .imageUrl(findPlaying.get().getImageUrl())
+                .category(playing.getCategory())
+                .title(playing.getTitle())
+                .date(playing.getDate())
+                .locate(playing.getLocate())
+                .cost(playing.getCost())
+                .imageUrl(playing.getImageUrl())
                 .build();
 
         return ResponseEntity.status(200)
@@ -386,38 +377,36 @@ public class PlayingServiceImpl implements PlayingService {
     public ResponseEntity<CustomAPIResponse<?>> cancelPlaying(Long playingId, PlayingApplyScrapRequestDTO playingApplyScrapRequestDTO, MyUserDetailsService.MyUserDetails userDetails) {
 
         String phoneId = userDetails.getPhoneId();
+        User user = userRepository.findByPhoneId(phoneId)
+                .orElseThrow(() -> new IllegalStateException("존재하지 않는 사용자입니다."));
 
         // 놀이터 게시글이 DB에 존재하는가?
         Optional<Playing> findPlaying = playingRepository.findById(playingId);
-        // 존재하는 사용자인가?
-        Optional<User> findUser = userRepository.findByPhoneId(phoneId);
-        // 존재하는 신청정보인가?
-        Optional<PlayingApply> findApply = playingApplyRepository.findByUserPhoneId(phoneId);
-
-        // 존재하지 않는다면 오류 반환
         if (findPlaying.isEmpty()) {
             return ResponseEntity.status(404)
                     .body(CustomAPIResponse.createFailWithout(404, "존재하지 않는 게시글입니다."));
-        } else if (findUser.isEmpty()) {
-            return ResponseEntity.status(404)
-                    .body(CustomAPIResponse.createFailWithout(404, "존재하지 않는 유저입니다."));
-        } else if (findApply.isEmpty()) {
+        }
+        Playing playing = findPlaying.get();
+
+        // 존재하는 신청정보인가?
+        Optional<PlayingApply> findApply = playingApplyRepository.findByUserPhoneId(phoneId);
+        if (findApply.isEmpty()) {
             return ResponseEntity.status(404)
                     .body(CustomAPIResponse.createFailWithout(404, "존재하지 않는 신청 정보입니다."));
         }
 
         // 게시글 작성자와 현재 작성자가 같다면 참가 취소 불가
-        if (findPlaying.get().getUser() == findUser.get()) {
+        if (playing.getUser().getPhoneId().equals(phoneId)) {
             return ResponseEntity.status(400)
                     .body(CustomAPIResponse.createFailWithout(400, "내가 올린 게시글에 참가 취소할 수 없습니다."));
         }
 
         // 해당 참가자의 참가를 취소하고, 해당 게시글의 인원을 한 명 줄인다.
         // 만약 정원이 다 찬 경우에서 취소한다면, 모집 완료를 모집 중으로 바꾼다.
-        if (findPlaying.get().getIsRecruit() == IsRecruit.FALSE) {
-            findPlaying.get().changeIsRecruit(IsRecruit.TRUE);
+        if (playing.getIsRecruit() == IsRecruit.FALSE) {
+            playing.changeIsRecruit(IsRecruit.TRUE);
         }
-        findPlaying.get().changeRecruitmentCount(findPlaying.get().getRecruitmentCount() - 1);
+        playing.changeRecruitmentCount(playing.getRecruitmentCount() - 1);
 
         playingApplyRepository.delete(findApply.get());
 
@@ -429,19 +418,14 @@ public class PlayingServiceImpl implements PlayingService {
     public ResponseEntity<CustomAPIResponse<?>> scrapPlaying(Long playingId, PlayingApplyScrapRequestDTO playingApplyScrapRequestDTO, MyUserDetailsService.MyUserDetails userDetails) {
 
         String phoneId = userDetails.getPhoneId();
+        User user = userRepository.findByPhoneId(phoneId)
+                .orElseThrow(() -> new IllegalStateException("존재하지 않는 사용자입니다."));
 
         // 놀이터 게시글이 DB에 존재하는가?
         Optional<Playing> findPlaying = playingRepository.findById(playingId);
-        // 존재하는 사용자인가?
-        Optional<User> findUser = userRepository.findByPhoneId(phoneId);
-
-        // 존재하지 않는다면 오류 반환
         if (findPlaying.isEmpty()) {
             return ResponseEntity.status(404)
                     .body(CustomAPIResponse.createFailWithout(404, "존재하지 않는 게시글입니다."));
-        } else if (findUser.isEmpty()) {
-            return ResponseEntity.status(404)
-                    .body(CustomAPIResponse.createFailWithout(404, "존재하지 않는 유저입니다."));
         }
 
         Optional<PlayingScrap> findPlayingScrap = playingScrapRepository.findByUserPhoneId(phoneId);
@@ -451,7 +435,7 @@ public class PlayingServiceImpl implements PlayingService {
         if (findPlayingScrap.isEmpty()) {
             PlayingScrap newScrap = PlayingScrap.builder()
                     .playing(findPlaying.get())
-                    .user(findUser.get())
+                    .user(user)
                     .build();
 
             playingScrapRepository.save(newScrap);
@@ -473,16 +457,9 @@ public class PlayingServiceImpl implements PlayingService {
 
         // 놀이터 게시글이 DB에 존재하는가?
         Optional<Playing> findPlaying = playingRepository.findById(playingId);
-        // 존재하는 사용자인가?
-        Optional<User> findUser = userRepository.findByPhoneId(phoneId);
-
-        // 존재하지 않는다면 오류 반환
         if (findPlaying.isEmpty()) {
             return ResponseEntity.status(404)
                     .body(CustomAPIResponse.createFailWithout(404, "존재하지 않는 게시글입니다."));
-        } else if (findUser.isEmpty()) {
-            return ResponseEntity.status(404)
-                    .body(CustomAPIResponse.createFailWithout(404, "존재하지 않는 유저입니다."));
         }
 
         Optional<PlayingScrap> findPlayingScrap = playingScrapRepository.findByUserPhoneId(phoneId);
@@ -517,6 +494,7 @@ public class PlayingServiceImpl implements PlayingService {
                     .imageUrl(playing.getImageUrl())
                     .build());
         }
+
         return ResponseEntity.status(200)
                 .body(CustomAPIResponse.createSuccess(200, playingResponses, "게시글 목록을 성공적으로 불러왔습니다."));
 

--- a/src/main/java/com/likelion/RePlay/domain/playing/service/PlayingServiceImpl.java
+++ b/src/main/java/com/likelion/RePlay/domain/playing/service/PlayingServiceImpl.java
@@ -501,4 +501,25 @@ public class PlayingServiceImpl implements PlayingService {
         
     }
 
+    @Override
+    public ResponseEntity<CustomAPIResponse<?>> getMyPlayings(MyUserDetailsService.MyUserDetails userDetails) {
+
+        String phoneId = userDetails.getPhoneId();
+
+        List<Playing> playings = playingRepository.findAllByUserPhoneId(phoneId);
+        List<PlayingListDTO.PlayingResponse> playingResponses = new ArrayList<>();
+
+        for (Playing playing : playings) {
+            playingResponses.add(PlayingListDTO.PlayingResponse.builder()
+                    .category(playing.getCategory())
+                    .title(playing.getTitle())
+                    .date(playing.getDate())
+                    .imageUrl(playing.getImageUrl())
+                    .build());
+        }
+        return ResponseEntity.status(200)
+                .body(CustomAPIResponse.createSuccess(200, playingResponses, "게시글 목록을 성공적으로 불러왔습니다."));
+
+    }
+
 }

--- a/src/main/java/com/likelion/RePlay/domain/playing/web/controller/PlayingController.java
+++ b/src/main/java/com/likelion/RePlay/domain/playing/web/controller/PlayingController.java
@@ -5,8 +5,10 @@ import com.likelion.RePlay.domain.playing.web.dto.PlayingFilteringDTO;
 import com.likelion.RePlay.domain.playing.web.dto.PlayingWriteRequestDTO;
 import com.likelion.RePlay.domain.playing.service.PlayingServiceImpl;
 import com.likelion.RePlay.global.response.CustomAPIResponse;
+import com.likelion.RePlay.global.security.MyUserDetailsService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -17,13 +19,13 @@ public class PlayingController {
     private final PlayingServiceImpl playingService;
 
     @PostMapping("/writePost")
-    private ResponseEntity<CustomAPIResponse<?>> writePost(@RequestBody PlayingWriteRequestDTO playingWriteRequestDTO) {
-        return playingService.writePost(playingWriteRequestDTO);
+    private ResponseEntity<CustomAPIResponse<?>> writePost(@RequestBody PlayingWriteRequestDTO playingWriteRequestDTO, @AuthenticationPrincipal MyUserDetailsService.MyUserDetails userDetails) {
+        return playingService.writePost(playingWriteRequestDTO, userDetails);
     }
 
     @PutMapping("/{playingId}")
-    private ResponseEntity<CustomAPIResponse<?>> modifyPost(@PathVariable Long playingId, @RequestBody PlayingWriteRequestDTO playingWriteRequestDTO) {
-        return playingService.modifyPost(playingId, playingWriteRequestDTO);
+    private ResponseEntity<CustomAPIResponse<?>> modifyPost(@PathVariable Long playingId, @RequestBody PlayingWriteRequestDTO playingWriteRequestDTO, @AuthenticationPrincipal MyUserDetailsService.MyUserDetails userDetails) {
+        return playingService.modifyPost(playingId, playingWriteRequestDTO, userDetails);
     }
 
     @GetMapping("/")
@@ -42,22 +44,22 @@ public class PlayingController {
     }
 
     @PostMapping("/{playingId}")
-    private ResponseEntity<CustomAPIResponse<?>> recruitPlaying(@PathVariable Long playingId, @RequestBody PlayingApplyScrapRequestDTO playingApplyScrapRequestDTO) {
-        return playingService.recruitPlaying(playingId, playingApplyScrapRequestDTO);
+    private ResponseEntity<CustomAPIResponse<?>> recruitPlaying(@PathVariable Long playingId, @RequestBody PlayingApplyScrapRequestDTO playingApplyScrapRequestDTO, @AuthenticationPrincipal MyUserDetailsService.MyUserDetails userDetails) {
+        return playingService.recruitPlaying(playingId, playingApplyScrapRequestDTO, userDetails);
     }
 
     @DeleteMapping("/{playingId}")
-    private ResponseEntity<CustomAPIResponse<?>> cancelPlaying(@PathVariable Long playingId, @RequestBody PlayingApplyScrapRequestDTO playingApplyScrapRequestDTO) {
-        return playingService.cancelPlaying(playingId, playingApplyScrapRequestDTO);
+    private ResponseEntity<CustomAPIResponse<?>> cancelPlaying(@PathVariable Long playingId, @RequestBody PlayingApplyScrapRequestDTO playingApplyScrapRequestDTO, @AuthenticationPrincipal MyUserDetailsService.MyUserDetails userDetails) {
+        return playingService.cancelPlaying(playingId, playingApplyScrapRequestDTO, userDetails);
     }
 
     @PostMapping("/{playingId}/scrap")
-    private ResponseEntity<CustomAPIResponse<?>> scrapPlaying(@PathVariable Long playingId, @RequestBody PlayingApplyScrapRequestDTO playingApplyScrapRequestDTO) {
-        return playingService.scrapPlaying(playingId, playingApplyScrapRequestDTO);
+    private ResponseEntity<CustomAPIResponse<?>> scrapPlaying(@PathVariable Long playingId, @RequestBody PlayingApplyScrapRequestDTO playingApplyScrapRequestDTO, @AuthenticationPrincipal MyUserDetailsService.MyUserDetails userDetails) {
+        return playingService.scrapPlaying(playingId, playingApplyScrapRequestDTO, userDetails);
     }
 
     @DeleteMapping("/{playingId}/scrap")
-    private ResponseEntity<CustomAPIResponse<?>> cancelScrap(@PathVariable Long playingId, @RequestBody PlayingApplyScrapRequestDTO playingApplyScrapRequestDTO) {
-        return playingService.cancelScrap(playingId, playingApplyScrapRequestDTO);
+    private ResponseEntity<CustomAPIResponse<?>> cancelScrap(@PathVariable Long playingId, @RequestBody PlayingApplyScrapRequestDTO playingApplyScrapRequestDTO, @AuthenticationPrincipal MyUserDetailsService.MyUserDetails userDetails) {
+        return playingService.cancelScrap(playingId, playingApplyScrapRequestDTO, userDetails);
     }
 }

--- a/src/main/java/com/likelion/RePlay/domain/playing/web/controller/PlayingController.java
+++ b/src/main/java/com/likelion/RePlay/domain/playing/web/controller/PlayingController.java
@@ -62,4 +62,9 @@ public class PlayingController {
     private ResponseEntity<CustomAPIResponse<?>> cancelScrap(@PathVariable Long playingId, @RequestBody PlayingApplyScrapRequestDTO playingApplyScrapRequestDTO, @AuthenticationPrincipal MyUserDetailsService.MyUserDetails userDetails) {
         return playingService.cancelScrap(playingId, playingApplyScrapRequestDTO, userDetails);
     }
+
+    @GetMapping("/myPlayings")
+    private ResponseEntity<CustomAPIResponse<?>> getMyPlayings(@AuthenticationPrincipal MyUserDetailsService.MyUserDetails userDetails) {
+        return playingService.getMyPlayings(userDetails);
+    }
 }

--- a/src/main/java/com/likelion/RePlay/domain/playing/web/dto/PlayingWriteRequestDTO.java
+++ b/src/main/java/com/likelion/RePlay/domain/playing/web/dto/PlayingWriteRequestDTO.java
@@ -13,8 +13,8 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 public class PlayingWriteRequestDTO {
-    @NotNull(message = "회원 아이디는 비워져 있을 수 없습니다.")
-    private String phoneId; // 게시글 작성자 아이디
+//    @NotNull(message = "회원 아이디는 비워져 있을 수 없습니다.")
+//    private String phoneId; // 게시글 작성자 아이디
     private String introduce; // 자기소개
     private String title;
     private String date;


### PR DESCRIPTION
## 📄 제목
내가 작성한 놀이터 게시글 조회 API

## 📖 설명
내가 작성한 놀이터 게시글을 조회할 수 있다.

## 🔍 관련 이슈
- 관련 이슈: #70 

## 🛠️ 변경 사항
- [x] QueryDSL 상속 코드 삭제
- [x] UserDetails 사용으로 불필요한 유저 존재 확인 코드 삭제
- [x] PlayingServiceImpl, PlayingController 기능에 맞게 코드 작성

## ✅ 체크리스트
- [x] 코드가 컴파일 및 빌드됨
- [x] 모든 테스트가 통과함
- [x] 관련 문서가 업데이트됨
- [x] 코드 리뷰가 수행됨