### PR TITLE
:ambulance: FIX. 스크랩 추가 및 삭제 오류 해결

### DIFF
--- a/src/main/java/com/likelion/RePlay/domain/learning/repository/LearningScrapRepository.java
+++ b/src/main/java/com/likelion/RePlay/domain/learning/repository/LearningScrapRepository.java
@@ -8,4 +8,5 @@ import java.util.Optional;
 
 public interface LearningScrapRepository extends JpaRepository<LearningScrap, Long> {
     Optional<LearningScrap> findByUserPhoneId(String phoneId);
+    Optional<LearningScrap> findByUserPhoneIdAndLearningLearningId(String phoneId, Long learningId);
 }

--- a/src/main/java/com/likelion/RePlay/domain/learning/service/LearningServiceImpl.java
+++ b/src/main/java/com/likelion/RePlay/domain/learning/service/LearningServiceImpl.java
@@ -401,7 +401,7 @@ public class LearningServiceImpl implements LearningService{
                     .body(CustomAPIResponse.createFailWithout(404, "존재하지 않는 유저입니다."));
         }
 
-        Optional<LearningScrap> findLearningScrap = learningScrapRepository.findByUserPhoneId(phoneId);
+        Optional<LearningScrap> findLearningScrap = learningScrapRepository.findByUserPhoneIdAndLearningLearningId(phoneId, learningId);
 
         if (findLearningScrap.isEmpty()) {
             LearningScrap newScrap = LearningScrap.builder()
@@ -435,7 +435,7 @@ public class LearningServiceImpl implements LearningService{
                     .body(CustomAPIResponse.createFailWithout(404, "존재하지 않는 유저입니다."));
         }
 
-        Optional<LearningScrap> findLearningScrap = learningScrapRepository.findByUserPhoneId(phoneId);
+        Optional<LearningScrap> findLearningScrap = learningScrapRepository.findByUserPhoneIdAndLearningLearningId(phoneId, learningId);
 
         if (findLearningScrap.isPresent()) {
             learningScrapRepository.delete(findLearningScrap.get());

--- a/src/main/java/com/likelion/RePlay/domain/playing/repository/PlayingScrapRepository.java
+++ b/src/main/java/com/likelion/RePlay/domain/playing/repository/PlayingScrapRepository.java
@@ -7,4 +7,5 @@ import java.util.Optional;
 
 public interface PlayingScrapRepository extends JpaRepository<PlayingScrap, Long> {
     Optional<PlayingScrap> findByUserPhoneId(String phoneId);
+    Optional<PlayingScrap> findByUserPhoneIdAndPlayingPlayingId(String phoneId, Long playingId);
 }

--- a/src/main/java/com/likelion/RePlay/domain/playing/service/PlayingServiceImpl.java
+++ b/src/main/java/com/likelion/RePlay/domain/playing/service/PlayingServiceImpl.java
@@ -419,7 +419,7 @@ public class PlayingServiceImpl implements PlayingService {
                     .body(CustomAPIResponse.createFailWithout(404, "존재하지 않는 게시글입니다."));
         }
 
-        Optional<PlayingScrap> findPlayingScrap = playingScrapRepository.findByUserPhoneId(phoneId);
+        Optional<PlayingScrap> findPlayingScrap = playingScrapRepository.findByUserPhoneIdAndPlayingPlayingId(phoneId, playingId);
 
         // 스크랩하지 않은 활동일 경우
         // 해당 게시글 신청 정보에 해당 유저의 정보를 추가한다.
@@ -453,7 +453,7 @@ public class PlayingServiceImpl implements PlayingService {
                     .body(CustomAPIResponse.createFailWithout(404, "존재하지 않는 게시글입니다."));
         }
 
-        Optional<PlayingScrap> findPlayingScrap = playingScrapRepository.findByUserPhoneId(phoneId);
+        Optional<PlayingScrap> findPlayingScrap = playingScrapRepository.findByUserPhoneIdAndPlayingPlayingId(phoneId, playingId);
 
         // 스크랩한 않은 활동일 경우 취소한다.
         if (findPlayingScrap.isPresent()) {


### PR DESCRIPTION
## 📄 제목
놀이터 및 배움터 게시글 스크랩 API 스크랩 오류

## 📖 설명
유저의 스크랩 수가 중복으로 체크되어, 한 번 스크랩 추가하면 다른 게시글에도 스크랩이 되지 않는 문제

## 🔍 관련 이슈
- 관련 이슈: #77 

## 🛠️ 변경 사항
- [x] PlayingScrapRepository 및 LearningScrapRepository에 findByUserPhoneIdAndPlayingPlayingId, findByUserPhoneIdAndLearningLearningId 추가
- [x] scrapPlaying, cancelScrap에서 findByUserPhoneId ->findByUserPhoneIdAndPlayingPlayingId
- [x]  scrapLearning, cancelScrap에서 findByUserPhoneId -> findByUserPhoneIdAndLearningLearningId

## ✅ 체크리스트
- [x] 코드가 컴파일 및 빌드됨
- [x] 모든 테스트가 통과함
- [x] 관련 문서가 업데이트됨
- [x] 코드 리뷰가 수행됨
