### PR TITLE
🚑️ FIX. 참가 신청 및 삭제 오류 해결

### DIFF
--- a/src/main/java/com/likelion/RePlay/domain/learning/repository/LearningApplyRepository.java
+++ b/src/main/java/com/likelion/RePlay/domain/learning/repository/LearningApplyRepository.java
@@ -7,4 +7,5 @@ import java.util.Optional;
 
 public interface LearningApplyRepository extends JpaRepository<LearningApply, Long> {
     Optional<LearningApply> findByUserPhoneId(String phoneId);
+    Optional<LearningApply> findByUserPhoneIdAndLearningLearningId(String phoneId, Long learningId);
 }

--- a/src/main/java/com/likelion/RePlay/domain/learning/service/LearningServiceImpl.java
+++ b/src/main/java/com/likelion/RePlay/domain/learning/service/LearningServiceImpl.java
@@ -309,7 +309,7 @@ public class LearningServiceImpl implements LearningService{
                     .body(CustomAPIResponse.createFailWithout(400, "모집 완료된 활동입니다."));
         }
 
-        Optional<LearningApply> findLearningApply = learningApplyRepository.findByUserPhoneId(phoneId);
+        Optional<LearningApply> findLearningApply = learningApplyRepository.findByUserPhoneIdAndLearningLearningId(phoneId, learningId);
 
         if (findLearningApply.isEmpty()) {
             LearningApply newApply = LearningApply.builder()
@@ -351,7 +351,7 @@ public class LearningServiceImpl implements LearningService{
         // 존재하는 사용자인가?
         Optional<User> findUser = userRepository.findByPhoneId(phoneId);
         // 존재하는 신청정보인가?
-        Optional<LearningApply> findApply = learningApplyRepository.findByUserPhoneId(phoneId);
+        Optional<LearningApply> findApply = learningApplyRepository.findByUserPhoneIdAndLearningLearningId(phoneId, learningId);
 
         // 존재하지 않는다면 오류 반환
         if (findLearning.isEmpty()) {

--- a/src/main/java/com/likelion/RePlay/domain/playing/repository/PlayingApplyRepository.java
+++ b/src/main/java/com/likelion/RePlay/domain/playing/repository/PlayingApplyRepository.java
@@ -8,4 +8,5 @@ import java.util.Optional;
 
 public interface PlayingApplyRepository extends JpaRepository<PlayingApply, Long> {
     Optional<PlayingApply> findByUserPhoneId(String phoneId);
+    Optional<PlayingApply> findByUserPhoneIdAndPlayingPlayingId(String phoneId, Long playingId);
 }

--- a/src/main/java/com/likelion/RePlay/domain/playing/service/PlayingServiceImpl.java
+++ b/src/main/java/com/likelion/RePlay/domain/playing/service/PlayingServiceImpl.java
@@ -326,7 +326,7 @@ public class PlayingServiceImpl implements PlayingService {
                     .body(CustomAPIResponse.createFailWithout(400, "모집 완료된 활동입니다."));
         }
 
-        Optional<PlayingApply> findPlayingApply = playingApplyRepository.findByUserPhoneId(phoneId);
+        Optional<PlayingApply> findPlayingApply = playingApplyRepository.findByUserPhoneIdAndPlayingPlayingId(phoneId, playingId);
 
         // 신청하지 않은 활동일 경우
         // 해당 게시글 신청 정보에 해당 유저의 정보를 추가한다.
@@ -380,7 +380,7 @@ public class PlayingServiceImpl implements PlayingService {
         Playing playing = findPlaying.get();
 
         // 존재하는 신청정보인가?
-        Optional<PlayingApply> findApply = playingApplyRepository.findByUserPhoneId(phoneId);
+        Optional<PlayingApply> findApply = playingApplyRepository.findByUserPhoneIdAndPlayingPlayingId(phoneId, playingId);
         if (findApply.isEmpty()) {
             return ResponseEntity.status(404)
                     .body(CustomAPIResponse.createFailWithout(404, "존재하지 않는 신청 정보입니다."));


### PR DESCRIPTION
## 📄 제목
놀이터 및 배움터 게시글 참가 API 참가 오류

## 📖 설명
유저의 참가 신청 수가 중복으로 체크되어, 한 번 참가 신청하면 다른 게시글에도 신청이 되지 않는 문제

## 🔍 관련 이슈
- 관련 이슈: #79 

## 🛠️ 변경 사항
- [ ] PlayingApplyRepository 및 LearningApplyRepository에 findByUserPhoneIdAndPlayingPlayingId, findByUserPhoneIdAndLearningLearningId 추가
- [ ] recruitPlaying, cancelRecruit에서 findByUserPhoneId ->findByUserPhoneIdAndPlayingPlayingId
- [ ] recruitLearning, cancelRecruit에서 findByUserPhoneId -> findByUserPhoneIdAndLearningLearningId

## ✅ 체크리스트
- [ ] 코드가 컴파일 및 빌드됨
- [ ] 모든 테스트가 통과함
- [ ] 관련 문서가 업데이트됨
- [ ] 코드 리뷰가 수행됨

