### PR TITLE
✨ FEAT. 내가 스크랩한 배움터 게시글 조회 API

### DIFF
--- a/src/main/java/com/likelion/RePlay/domain/learning/repository/LearningScrapRepository.java
+++ b/src/main/java/com/likelion/RePlay/domain/learning/repository/LearningScrapRepository.java
@@ -4,9 +4,12 @@ import com.likelion.RePlay.domain.learning.entity.LearningApply;
 import com.likelion.RePlay.domain.learning.entity.LearningScrap;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface LearningScrapRepository extends JpaRepository<LearningScrap, Long> {
+
+    List<LearningScrap> findAllByUserUserId(Long userId);
     Optional<LearningScrap> findByUserPhoneId(String phoneId);
     Optional<LearningScrap> findByUserPhoneIdAndLearningLearningId(String phoneId, Long learningId);
 }

--- a/src/main/java/com/likelion/RePlay/domain/learning/service/LearningService.java
+++ b/src/main/java/com/likelion/RePlay/domain/learning/service/LearningService.java
@@ -27,4 +27,6 @@ public interface LearningService {
     ResponseEntity<CustomAPIResponse<?>> cancelScrap(Long learningId, MyUserDetailsService.MyUserDetails userDetails);
 
     ResponseEntity<CustomAPIResponse<?>> recruitedLearnings(MyUserDetailsService.MyUserDetails userDetails);
+
+    ResponseEntity<CustomAPIResponse<?>> scrapLearnings(MyUserDetailsService.MyUserDetails userDetails);
 }

--- a/src/main/java/com/likelion/RePlay/domain/learning/service/LearningServiceImpl.java
+++ b/src/main/java/com/likelion/RePlay/domain/learning/service/LearningServiceImpl.java
@@ -467,5 +467,32 @@ public class LearningServiceImpl implements LearningService{
 
     }
 
+    @Override
+    public ResponseEntity<CustomAPIResponse<?>> scrapLearnings(MyUserDetailsService.MyUserDetails userDetails) {
+
+        String phoneId = userDetails.getPhoneId();
+        User user = userRepository.findByPhoneId(phoneId)
+                .orElseThrow(() -> new IllegalStateException("존재하지 않는 사용자입니다."));
+        Long userId = user.getUserId();
+
+        List<LearningScrap> learningScraps = learningScrapRepository.findAllByUserUserId(userId);
+        List<LearningListDTO.LearningResponse> learningResponses = new ArrayList<>();
+
+        for (int i = 0; i < learningScraps.size(); i++) {
+            Learning learning = learningScraps.get(i).getLearning();
+
+            learningResponses.add(LearningListDTO.LearningResponse.builder()
+                    .category(learning.getCategory())
+                    .title(learning.getTitle())
+                    .date(learning.getDate())
+                    .imageUrl(learning.getImageUrl())
+                    .build());
+        }
+
+        return ResponseEntity.status(200)
+                .body(CustomAPIResponse.createSuccess(200, learningResponses, "스크랩한 게시글 목록을 성공적으로 불러왔습니다."));
+
+    }
+
 
 }

--- a/src/main/java/com/likelion/RePlay/domain/learning/web/controller/LearningController.java
+++ b/src/main/java/com/likelion/RePlay/domain/learning/web/controller/LearningController.java
@@ -69,4 +69,9 @@ public class LearningController {
         return learningService.recruitedLearnings(userDetails);
     }
 
+    @GetMapping("/scrap")
+    private ResponseEntity<CustomAPIResponse<?>> scrapLearnings(@AuthenticationPrincipal MyUserDetailsService.MyUserDetails userDetails) {
+        return learningService.scrapLearnings(userDetails);
+    }
+
 }


### PR DESCRIPTION
## 📄 제목
내가 스크랩한 배움터 게시글 조회 API

## 📖 설명
내가 스크랩한 배움터 게시글들을 조회할 수 있다.

## 🔍 관련 이슈
- 관련 이슈: #87 

## 🛠️ 변경 사항
구현하거나 수정한 주요 내용을 나열해주세요.
- [x] LearningServiceImpl, LearningController 기능에 맞게 작성
- [x] LearningScrapRepository findAllByUserUserId 추가

## ✅ 체크리스트
- [x] 코드가 컴파일 및 빌드됨
- [x] 모든 테스트가 통과함
- [x] 관련 문서가 업데이트됨
- [x] 코드 리뷰가 수행됨
