### PR TITLE
✨ FEAT. 놀이터 게시글 댓글 삭제 API

### DIFF
--- a/src/main/java/com/likelion/RePlay/domain/playing/service/PlayingService.java
+++ b/src/main/java/com/likelion/RePlay/domain/playing/service/PlayingService.java
@@ -42,4 +42,6 @@ public interface PlayingService {
     ResponseEntity<CustomAPIResponse<?>> commentPlaying(Long playingId, PlayingCommentWriteRequestDTO playingCommentWriteRequestDTO, MyUserDetailsService.MyUserDetails userDetails);
 
     ResponseEntity<CustomAPIResponse<?>> getAllComments(Long playingId);
+
+    ResponseEntity<CustomAPIResponse<?>> deleteComment(Long commentId, MyUserDetailsService.MyUserDetails userDetails);
 }

--- a/src/main/java/com/likelion/RePlay/domain/playing/service/PlayingServiceImpl.java
+++ b/src/main/java/com/likelion/RePlay/domain/playing/service/PlayingServiceImpl.java
@@ -688,4 +688,32 @@ public class PlayingServiceImpl implements PlayingService {
                 .body(CustomAPIResponse.createSuccess(201, commentResponses, "해당 게시글의 댓글과 답글을 불러왔습니다."));
     }
 
+    @Override
+    public ResponseEntity<CustomAPIResponse<?>> deleteComment(Long commentId, MyUserDetailsService.MyUserDetails userDetails) {
+
+        String phoneId = userDetails.getPhoneId();
+        User user = userRepository.findByPhoneId(phoneId)
+                .orElseThrow(() -> new IllegalStateException("존재하지 않는 사용자입니다."));
+
+        Optional<PlayingComment> findComment = playingCommentRepository.findById(commentId);
+        if (findComment.isEmpty()) {
+            return ResponseEntity.status(404)
+                    .body(CustomAPIResponse.createFailWithout(404, "존재하지 않는 댓글입니다."));
+        }
+
+        PlayingComment comment = findComment.get();
+
+        // 사용자가 해당 게시글의 작성자인지 확인
+        if (!comment.getUser().getPhoneId().equals(phoneId)) {
+            return ResponseEntity.status(403)
+                    .body(CustomAPIResponse.createFailWithout(403, "본인이 작성한 댓글만 삭제할 수 있습니다."));
+        }
+
+        playingCommentRepository.delete(comment);
+
+        return ResponseEntity.status(200)
+                .body(CustomAPIResponse.createSuccess(200, null, "댓글 삭제를 성공했습니다."));
+
+    }
+
 }

--- a/src/main/java/com/likelion/RePlay/domain/playing/web/controller/PlayingController.java
+++ b/src/main/java/com/likelion/RePlay/domain/playing/web/controller/PlayingController.java
@@ -99,4 +99,9 @@ public class PlayingController {
         return playingService.getAllComments(playingId);
     }
 
+    @DeleteMapping("/{commentId}/comment")
+    private ResponseEntity<CustomAPIResponse<?>> deleteComment(@PathVariable Long commentId, @AuthenticationPrincipal MyUserDetailsService.MyUserDetails userDetails) {
+        return playingService.deleteComment(commentId, userDetails);
+    }
+
 }


### PR DESCRIPTION
## 📄 제목
놀이터 게시글 댓글 삭제 API

## 📖 설명
본인이 작성한 댓글을 삭제할 수 있다. 댓글이 삭제되면 하위의 답글도 사라진다. 게시글이 사라지면 하위의 댓글도 사라진다.

## 🔍 관련 이슈
- 관련 이슈: #96 

## 🛠️ 변경 사항
- [x] PlayingController, PlayingServiceImpl 기능에 맞게 작성

## ✅ 체크리스트
- [x] 코드가 컴파일 및 빌드됨
- [x] 모든 테스트가 통과함
- [x] 관련 문서가 업데이트됨
- [x] 코드 리뷰가 수행됨
