### PR TITLE
✨ FEAT. 배움터 게시글 모든 댓글 조회 API

### DIFF
--- a/src/main/java/com/likelion/RePlay/domain/learning/entity/LearningComment.java
+++ b/src/main/java/com/likelion/RePlay/domain/learning/entity/LearningComment.java
@@ -19,8 +19,8 @@ public class LearningComment extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name="Learning_COMMENT_ID")
-    private Long LearningCommentId;
+    @Column(name="LEARNING_COMMENT_ID")
+    private Long learningCommentId;
 
     @Column(name="CONTENT")
     private String content;

--- a/src/main/java/com/likelion/RePlay/domain/learning/service/LearningService.java
+++ b/src/main/java/com/likelion/RePlay/domain/learning/service/LearningService.java
@@ -32,4 +32,6 @@ public interface LearningService {
     ResponseEntity<CustomAPIResponse<?>> scrapLearnings(MyUserDetailsService.MyUserDetails userDetails);
 
     ResponseEntity<CustomAPIResponse<?>> commentLearning(Long learningId, LearningCommentWriteRequestDTO learningCommentWriteRequestDTO, MyUserDetailsService.MyUserDetails userDetails);
+
+    ResponseEntity<CustomAPIResponse<?>> getAllComments(Long learningId);
 }

--- a/src/main/java/com/likelion/RePlay/domain/learning/service/LearningServiceImpl.java
+++ b/src/main/java/com/likelion/RePlay/domain/learning/service/LearningServiceImpl.java
@@ -12,6 +12,7 @@ import com.likelion.RePlay.domain.learning.web.dto.LearningCommentWriteRequestDT
 import com.likelion.RePlay.domain.learning.web.dto.LearningFilteringDTO;
 import com.likelion.RePlay.domain.learning.web.dto.LearningListDTO;
 import com.likelion.RePlay.domain.learning.web.dto.LearningWriteRequestDTO;
+import com.likelion.RePlay.domain.playing.web.dto.CommentListDTO;
 import com.likelion.RePlay.domain.user.entity.User;
 import com.likelion.RePlay.domain.user.repository.UserRepository;
 import com.likelion.RePlay.global.enums.*;
@@ -540,6 +541,39 @@ public class LearningServiceImpl implements LearningService{
 
         return ResponseEntity.status(201)
                 .body(CustomAPIResponse.createSuccess(201, null, "댓글을 작성하였습니다."));
+
+    }
+
+    @Override
+    public ResponseEntity<CustomAPIResponse<?>> getAllComments(Long learningId) {
+
+        List<LearningComment> learningComments = learningCommentRepository.findAllByLearningLearningId(learningId);
+        List<CommentListDTO.CommentResponse> commentResponses = new ArrayList<>();
+
+        Optional<Learning> findLearning = learningRepository.findById(learningId);
+        if (findLearning.isEmpty()) {
+            return ResponseEntity.status(404)
+                    .body(CustomAPIResponse.createFailWithout(404, "게시글을 찾을 수 없습니다."));
+        }
+
+        for (LearningComment learningComment : learningComments) {
+            Long parentCommentId = 0L;
+
+            if (learningComment.getParent() != null) {
+                parentCommentId = learningComment.getParent().getLearningCommentId();
+            }
+
+            commentResponses.add(CommentListDTO.CommentResponse.builder()
+                    .content(learningComment.getContent())
+                    .date(learningComment.getDate())
+                    .nickname(learningComment.getUser().getNickname())
+                    .commentId(learningComment.getLearningCommentId())
+                    .parentCommentId(parentCommentId)
+                    .build());
+        }
+
+        return ResponseEntity.status(201)
+                .body(CustomAPIResponse.createSuccess(201, commentResponses, "해당 게시글의 댓글과 답글을 불러왔습니다."));
 
     }
 

--- a/src/main/java/com/likelion/RePlay/domain/learning/web/controller/LearningController.java
+++ b/src/main/java/com/likelion/RePlay/domain/learning/web/controller/LearningController.java
@@ -81,4 +81,9 @@ public class LearningController {
         return learningService.commentLearning(learningId, learningCommentWriteRequestDTO, userDetails);
     }
 
+    @GetMapping("/comment/{learningId}")
+    private ResponseEntity<CustomAPIResponse<?>> getAllComments(@PathVariable Long learningId) {
+        return learningService.getAllComments(learningId);
+    }
+
 }

--- a/src/main/java/com/likelion/RePlay/global/security/SecurityConfig.java
+++ b/src/main/java/com/likelion/RePlay/global/security/SecurityConfig.java
@@ -33,7 +33,7 @@ public class SecurityConfig {
                                 "/api/user/isExistNickName","/api/user/isExistPhoneId", "/api/user/getMyPage").permitAll()
                         .requestMatchers("/api/playing/getPlayings/**", "/api/playing/comment/**").permitAll()
                         .requestMatchers("/api/info/getAllInfo", "/api/info/getOneInfo/**").permitAll()
-                        .requestMatchers(("/api/learning/getLearning/**")).permitAll()
+                        .requestMatchers("/api/learning/getLearning/**", "/api/learning/comment/**").permitAll()
                         // 로그인한 사용자만 접근 가능
                         .requestMatchers("/api/user/**").authenticated()
                         .requestMatchers("/api/playing/**").authenticated()


### PR DESCRIPTION
## 📄 제목
배움터 게시글 모든 댓글 조회 API

## 📖 설명
게시글의 기본키로 DB에서 모든 댓글을 불러와 response로 넘겨준다.

## 🔍 관련 이슈
- 관련 이슈: #101 

## 🛠️ 변경 사항
구현하거나 수정한 주요 내용을 나열해주세요.
- [x] LearningController, LearningServiceImpl 기능에 맞게 작성
- [x] SecurityConfig 경로 수정

## ✅ 체크리스트
- [x] 코드가 컴파일 및 빌드됨
- [x] 모든 테스트가 통과함
- [x] 관련 문서가 업데이트됨
- [ ] 코드 리뷰가 수행됨