### PR TITLE
✨ FEAT. 배움터 게시글 댓글 삭제 API

### DIFF
--- a/src/main/java/com/likelion/RePlay/domain/learning/service/LearningService.java
+++ b/src/main/java/com/likelion/RePlay/domain/learning/service/LearningService.java
@@ -34,4 +34,6 @@ public interface LearningService {
     ResponseEntity<CustomAPIResponse<?>> commentLearning(Long learningId, LearningCommentWriteRequestDTO learningCommentWriteRequestDTO, MyUserDetailsService.MyUserDetails userDetails);
 
     ResponseEntity<CustomAPIResponse<?>> getAllComments(Long learningId);
+
+    ResponseEntity<CustomAPIResponse<?>> deleteComment(Long commentId, MyUserDetailsService.MyUserDetails userDetails);
 }

--- a/src/main/java/com/likelion/RePlay/domain/learning/service/LearningServiceImpl.java
+++ b/src/main/java/com/likelion/RePlay/domain/learning/service/LearningServiceImpl.java
@@ -577,5 +577,31 @@ public class LearningServiceImpl implements LearningService{
 
     }
 
+    @Override
+    public ResponseEntity<CustomAPIResponse<?>> deleteComment(Long commentId, MyUserDetailsService.MyUserDetails userDetails) {
+        String phoneId = userDetails.getPhoneId();
+        User user = userRepository.findByPhoneId(phoneId)
+                .orElseThrow(() -> new IllegalStateException("존재하지 않는 사용자입니다."));
+
+        Optional<LearningComment> findComment = learningCommentRepository.findById(commentId);
+        if (findComment.isEmpty()) {
+            return ResponseEntity.status(404)
+                    .body(CustomAPIResponse.createFailWithout(404, "존재하지 않는 댓글입니다."));
+        }
+
+        LearningComment comment = findComment.get();
+
+        if (!comment.getUser().getPhoneId().equals(phoneId)) {
+            return ResponseEntity.status(403)
+                    .body(CustomAPIResponse.createFailWithout(403, "본인이 작성한 댓글만 삭제할 수 있습니다."));
+        }
+
+        learningCommentRepository.delete(comment);
+
+        return ResponseEntity.status(200)
+                .body(CustomAPIResponse.createSuccess(200, null, "댓글 삭제를 성공했습니다."));
+
+    }
+
 
 }

--- a/src/main/java/com/likelion/RePlay/domain/learning/web/controller/LearningController.java
+++ b/src/main/java/com/likelion/RePlay/domain/learning/web/controller/LearningController.java
@@ -86,4 +86,9 @@ public class LearningController {
         return learningService.getAllComments(learningId);
     }
 
+    @DeleteMapping("/{commentId}/comment")
+    private ResponseEntity<CustomAPIResponse<?>> deleteComment(@PathVariable Long commentId, @AuthenticationPrincipal MyUserDetailsService.MyUserDetails userDetails) {
+        return learningService.deleteComment(commentId, userDetails);
+    }
+
 }


### PR DESCRIPTION
## 📄 제목
배움터 게시글 댓글 삭제 API

## 📖 설명
본인이 작성한 댓글을 삭제할 수 있다. 댓글이 삭제되면 하위의 답글도 사라진다. 게시글이 사라지면 하위의 댓글도 사라진다.

## 🔍 관련 이슈
- 관련 이슈: #98  

## 🛠️ 변경 사항
- [x] LearningController, LearningServiceImpl 기능에 맞게 작성

## ✅ 체크리스트
PR을 제출하기 전에 완료해야 할 항목들을 나열해주세요.
- [x] 코드가 컴파일 및 빌드됨
- [x] 모든 테스트가 통과함
- [x] 관련 문서가 업데이트됨
- [x] 코드 리뷰가 수행됨
