### PR TITLE
🐛 필터링 API 오류 수정

### DIFF
--- a/src/main/java/com/likelion/RePlay/domain/learning/service/LearningServiceImpl.java
+++ b/src/main/java/com/likelion/RePlay/domain/learning/service/LearningServiceImpl.java
@@ -308,6 +308,10 @@ public class LearningServiceImpl implements LearningService{
                         return matches;
                     })
                     .collect(Collectors.toList());
+        } else if (learningFilteringDTO.getDistrictList() != null && !learningFilteringDTO.getDistrictList().isEmpty()) {
+            // state가 없는데 district가 있는 경우 오류 반환
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(CustomAPIResponse.createFailWithout(HttpStatus.BAD_REQUEST.value(), "State가 선택되지 않았습니다."));
         }
 
         List<Learning> filteredByCategory = filteredByLocation;

--- a/src/main/java/com/likelion/RePlay/domain/learning/web/dto/LearningWriteRequestDTO.java
+++ b/src/main/java/com/likelion/RePlay/domain/learning/web/dto/LearningWriteRequestDTO.java
@@ -3,7 +3,9 @@ package com.likelion.RePlay.domain.learning.web.dto;
 import com.likelion.RePlay.global.enums.Category;
 import com.likelion.RePlay.global.enums.District;
 import com.likelion.RePlay.global.enums.State;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import lombok.*;
 
 @Getter
@@ -12,19 +14,34 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 public class LearningWriteRequestDTO {
-    //private String phoneId;
+
+    @NotEmpty(message = "제목은 비워져 있을 수 없습니다.")
     private String title;
+
+    @NotEmpty(message = "날짜는 비워져 있을 수 없습니다.")
     private String date;
+
+    @NotEmpty(message = "주소는 비워져 있을 수 없습니다.")
     private String locate; // 카카오맵으로 검색한 주소
+
     private double latitude; // 카카오맵에서 받아온 위도
     private double longitude; // 카카오맵에서 받아온 경도
+
+    @NotNull(message = "시는 비워져 있을 수 없습니다.")
     private State state;
+
+    @NotNull(message = "구는 비워져 있을 수 없습니다.")
     private District district;
+
+    @NotNull(message = "카테고리는 비워져 있을 수 없습니다.")
     private Category category;
+
     private String content; // 배움 설명
 
-    @NotNull(message = "모집 인원을 입력해주세요.")
+    @NotNull(message = "총 인원은 비워져 있을 수 없습니다.")
+    @Positive(message = "총 인원은 양수여야 합니다.")
     private Long totalCount;
+
     private String learningImage;
 
     // 멘토 이름 추가

--- a/src/main/java/com/likelion/RePlay/domain/playing/service/PlayingServiceImpl.java
+++ b/src/main/java/com/likelion/RePlay/domain/playing/service/PlayingServiceImpl.java
@@ -287,6 +287,10 @@ public class PlayingServiceImpl implements PlayingService {
                         return matches;
                     })
                     .collect(Collectors.toList());
+        } else if (playingFilteringDTO.getDistrictList() != null && !playingFilteringDTO.getDistrictList().isEmpty()) {
+            // state가 없는데 district가 있는 경우 오류 반환
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(CustomAPIResponse.createFailWithout(HttpStatus.BAD_REQUEST.value(), "State가 선택되지 않았습니다."));
         }
 
         // 5. Category 조건과 일치하는 게시글만 남기기 (Null일 경우 필터링하지 않음)

--- a/src/main/java/com/likelion/RePlay/domain/playing/web/dto/PlayingWriteRequestDTO.java
+++ b/src/main/java/com/likelion/RePlay/domain/playing/web/dto/PlayingWriteRequestDTO.java
@@ -4,6 +4,9 @@ package com.likelion.RePlay.domain.playing.web.dto;
 import com.likelion.RePlay.global.enums.Category;
 import com.likelion.RePlay.global.enums.District;
 import com.likelion.RePlay.global.enums.State;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import lombok.*;
 
 @Getter
@@ -12,20 +15,40 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 public class PlayingWriteRequestDTO {
-//    @NotNull(message = "회원 아이디는 비워져 있을 수 없습니다.")
-//    private String phoneId; // 게시글 작성자 아이디
+
     private String introduce; // 자기소개
+
+    @NotEmpty(message = "제목은 비워져 있을 수 없습니다.")
     private String title;
+
+    @NotEmpty(message = "날짜는 비워져 있을 수 없습니다.")
     private String date;
+
+    @NotEmpty(message = "주소는 비워져 있을 수 없습니다.")
     private String locate; // 카카오맵으로 검색한 주소
+
     private double latitude; // 카카오맵에서 받아온 위도
     private double longitude; // 카카오맵에서 받아온 경도
+
+    @NotNull(message = "시는 비워져 있을 수 없습니다.")
     private State state;
+
+    @NotNull(message = "구는 비워져 있을 수 없습니다.")
     private District district;
+
+    @NotNull(message = "카테고리는 비워져 있을 수 없습니다.")
     private Category category;
+
     private String content; // 놀이 설명
+
+    @NotNull(message = "총 인원은 비워져 있을 수 없습니다.")
+    @Positive(message = "총 인원은 양수여야 합니다.")
     private Long totalCount;
+
+    @NotNull(message = "참가 비용은 비워져 있을 수 없습니다.")
+    @Positive(message = "참가 비용은 양수여야 합니다.")
     private Long cost; // 참가비용
-    private String costDescription; //참가비용 설명
+
+    private String costDescription; // 참가비용 설명
     private String playingImage;
 }


### PR DESCRIPTION
## 📄 제목
🐛 필터링 API 오류 수정

## 📖 설명
시를 선택하지 않고 구를 선택해도 오류가 나지 않는다. 시를 선택하지 않는 데이터가 전달되었을 경우, 오류를 반환한다.

## 🔍 관련 이슈
- 관련 이슈: #111 

## 🛠️ 변경 사항
- [x] DTO에 NotNull, NotEmpty 어노테이션 추가
- [x] State 선택하지 않고 District만 전달될 시 오류 반환 로직 추가

## ✅ 체크리스트
- [x] 코드가 컴파일 및 빌드됨
- [x] 모든 테스트가 통과함
- [x] 관련 문서가 업데이트됨
- [x] 코드 리뷰가 수행됨
