### PR TITLE
🩹 FIX. 멘토 추가에 따른 배움터 게시글 API 수정

### DIFF
--- a/src/main/java/com/likelion/RePlay/domain/learning/entity/LearningMentor.java
+++ b/src/main/java/com/likelion/RePlay/domain/learning/entity/LearningMentor.java
@@ -18,4 +18,12 @@ public class LearningMentor extends BaseEntity {
 
     @Column
     private String mentorName;
+
+    @Column
+    private String introduce;
+
+    // 연관관계 편의 메서드
+    public void changeIntroduce(String introduce) {
+        this.introduce = introduce;
+    }
 }

--- a/src/main/java/com/likelion/RePlay/domain/learning/service/LearningServiceImpl.java
+++ b/src/main/java/com/likelion/RePlay/domain/learning/service/LearningServiceImpl.java
@@ -61,10 +61,12 @@ public class LearningServiceImpl implements LearningService{
         if(isExist.isEmpty()){
             mentor= LearningMentor.builder()
                     .mentorName(learningWriteRequestDTO.getMentorName())
+                    .introduce(learningWriteRequestDTO.getIntroduce())
                     .build();
             learningMentorRepository.save(mentor);
         }else {
             mentor = isExist.get();
+            mentor.changeIntroduce(learningWriteRequestDTO.getIntroduce());
         }
 
         String dateStr = learningWriteRequestDTO.getDate();

--- a/src/main/java/com/likelion/RePlay/domain/learning/service/LearningServiceImpl.java
+++ b/src/main/java/com/likelion/RePlay/domain/learning/service/LearningServiceImpl.java
@@ -240,7 +240,6 @@ public class LearningServiceImpl implements LearningService{
 
         LearningListDTO.LearningResponse  learningResponse = LearningListDTO.LearningResponse.builder()
                 .nickname(user.getNickname())
-                .introduce(user.getIntroduce())
                 .category(findLearning.get().getCategory())
                 .title(findLearning.get().getTitle())
                 .date(findLearning.get().getDate())
@@ -252,6 +251,7 @@ public class LearningServiceImpl implements LearningService{
                 .content(findLearning.get().getContent())
                 .imageUrl(findLearning.get().getImageUrl())
                 .mentorName(findLearning.get().getLearningMentor().getMentorName())
+                .introduce(findLearning.get().getLearningMentor().getIntroduce())
                 .build();
 
         return ResponseEntity.status(200)

--- a/src/main/java/com/likelion/RePlay/domain/learning/service/LearningServiceImpl.java
+++ b/src/main/java/com/likelion/RePlay/domain/learning/service/LearningServiceImpl.java
@@ -135,10 +135,12 @@ public class LearningServiceImpl implements LearningService{
         if(isExist.isEmpty()){
             mentor= LearningMentor.builder()
                     .mentorName(learningWriteRequestDTO.getMentorName())
+                    .introduce(learningWriteRequestDTO.getIntroduce())
                     .build();
             learningMentorRepository.save(mentor);
         }else {
             mentor = isExist.get();
+            mentor.changeIntroduce(learningWriteRequestDTO.getIntroduce());
         }
 
         Learning learning = findLearning.get();

--- a/src/main/java/com/likelion/RePlay/domain/learning/web/dto/LearningListDTO.java
+++ b/src/main/java/com/likelion/RePlay/domain/learning/web/dto/LearningListDTO.java
@@ -19,7 +19,6 @@ public class LearningListDTO {
     @AllArgsConstructor
     public static class LearningResponse {
         private String nickname;
-        private String introduce;
         private Category category;
         private String title;
         private String content;
@@ -36,6 +35,7 @@ public class LearningListDTO {
 
         // 멘토 추가
         private String mentorName;
+        private String introduce;
     }
 
     @Getter @Setter

--- a/src/main/java/com/likelion/RePlay/domain/learning/web/dto/LearningWriteRequestDTO.java
+++ b/src/main/java/com/likelion/RePlay/domain/learning/web/dto/LearningWriteRequestDTO.java
@@ -46,4 +46,7 @@ public class LearningWriteRequestDTO {
 
     // 멘토 이름 추가
     private String mentorName;
+
+    // 멘토 소개 추가
+    private String introduce;
 }


### PR DESCRIPTION
## 📄 제목
🩹 FIX. 멘토 추가에 따른 배움터 게시글 API 수정

## 📖 설명
배움터 게시글 작성, 수정 API에서 멘토 이름과 멘토 소개를 입력받을 수 있다. 배움터 특정 게시글 조회 API에서 멘토를 조회할 수 있다.

## 🔍 관련 이슈
- 관련 이슈: #117 

## 🛠️ 변경 사항
- [x] LearningMentor introduce 및 연관관계 편의 메서드 추가
- [x] LearningServiceImpl writePost, modifyPost, getPost 수정

## ✅ 체크리스트
PR을 제출하기 전에 완료해야 할 항목들을 나열해주세요.
- [x] 코드가 컴파일 및 빌드됨
- [x] 모든 테스트가 통과함
- [x] 관련 문서가 업데이트됨
- [x] 코드 리뷰가 수행됨

