### PR TITLE
✨ FEAT. 놀이터 게시글 참가자 조회 API

### DIFF
--- a/src/main/java/com/likelion/RePlay/domain/playing/repository/PlayingApplyRepository.java
+++ b/src/main/java/com/likelion/RePlay/domain/playing/repository/PlayingApplyRepository.java
@@ -9,6 +9,7 @@ import java.util.Optional;
 
 public interface PlayingApplyRepository extends JpaRepository<PlayingApply, Long> {
     List<PlayingApply> findAllByUserUserId(Long userId);
+    List<PlayingApply> findAllByPlayingPlayingId(Long playingId);
     Optional<PlayingApply> findByUserPhoneId(String phoneId);
     Optional<PlayingApply> findByUserPhoneIdAndPlayingPlayingId(String phoneId, Long playingId);
 }

--- a/src/main/java/com/likelion/RePlay/domain/playing/service/PlayingService.java
+++ b/src/main/java/com/likelion/RePlay/domain/playing/service/PlayingService.java
@@ -53,4 +53,5 @@ public interface PlayingService {
     ResponseEntity<CustomAPIResponse<?>> getUserReview(UserReviewRequestDto userReviewRequestDto);
 
 
+    ResponseEntity<CustomAPIResponse<?>> getApplicant(Long playingId, MyUserDetailsService.MyUserDetails userDetails);
 }

--- a/src/main/java/com/likelion/RePlay/domain/playing/web/controller/PlayingController.java
+++ b/src/main/java/com/likelion/RePlay/domain/playing/web/controller/PlayingController.java
@@ -132,4 +132,11 @@ public class PlayingController {
         return playingService.getUserReview(userReviewRequestDto);
     }
 
+    // 신청자 조회
+    @GetMapping("/getApplicant/{playingId}")
+    private ResponseEntity<CustomAPIResponse<?>> getApplicant(@PathVariable Long playingId, @AuthenticationPrincipal MyUserDetailsService.MyUserDetails userDetails) {
+        return playingService.getApplicant(playingId, userDetails);
+    }
+
+
 }

--- a/src/main/java/com/likelion/RePlay/domain/playing/web/dto/ApplicantListDTO.java
+++ b/src/main/java/com/likelion/RePlay/domain/playing/web/dto/ApplicantListDTO.java
@@ -1,0 +1,30 @@
+package com.likelion.RePlay.domain.playing.web.dto;
+
+import lombok.*;
+
+import java.util.List;
+
+public class ApplicantListDTO {
+
+    @Getter
+    @Setter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ApplicantResponse {
+        private String nickname;
+        private String phoneId;
+        private String profileImage;
+    }
+
+    @Getter @Setter
+    @Builder
+    @NoArgsConstructor
+    public static class SearchApplicant {
+        private List<ApplicantResponse> applicantResponses;
+
+        public SearchApplicant(List<ApplicantResponse> applicantResponses) {
+            this.applicantResponses = applicantResponses;
+        }
+    }
+}


### PR DESCRIPTION
## 📄 제목
놀이터 게시글 참가자 조회 API

## 📖 설명
게시글 작성자는 참가 신청자들의 정보를 볼 수 있다.

## 🔍 관련 이슈
- 관련 이슈: #119 

## 🛠️ 변경 사항
- [x] PlayingApplyRepository playingId 쿼리문 추가
- [x] 응답으로 전달할 ApplicantListDTO 추가
- [x] PlayingServiceImpl 기능에 맞게 작성

## ✅ 체크리스트
PR을 제출하기 전에 완료해야 할 항목들을 나열해주세요.
- [x] 코드가 컴파일 및 빌드됨
- [x] 모든 테스트가 통과함
- [x] 관련 문서가 업데이트됨
- [x] 코드 리뷰가 수행됨
