### PR TITLE
✨ FEAT. 배움터 게시글 참가자 정보 조회 API

### DIFF
--- a/src/main/java/com/likelion/RePlay/domain/learning/repository/LearningApplyRepository.java
+++ b/src/main/java/com/likelion/RePlay/domain/learning/repository/LearningApplyRepository.java
@@ -9,6 +9,8 @@ import java.util.Optional;
 public interface LearningApplyRepository extends JpaRepository<LearningApply, Long> {
 
     List<LearningApply> findAllByUserUserId(Long userId);
+
+    List<LearningApply> findAllByLearningLearningId(Long learningId);
     Optional<LearningApply> findByUserPhoneId(String phoneId);
     Optional<LearningApply> findByUserPhoneIdAndLearningLearningId(String phoneId, Long learningId);
 

--- a/src/main/java/com/likelion/RePlay/domain/learning/service/LearningService.java
+++ b/src/main/java/com/likelion/RePlay/domain/learning/service/LearningService.java
@@ -43,4 +43,5 @@ public interface LearningService {
 
     ResponseEntity<CustomAPIResponse<?>> getMentorReview(MentorReviewRequestDto mentorReviewRequestDto);
 
+    ResponseEntity<CustomAPIResponse<?>> getApplicant(Long learningId, MyUserDetailsService.MyUserDetails userDetails);
 }

--- a/src/main/java/com/likelion/RePlay/domain/learning/web/controller/LearningController.java
+++ b/src/main/java/com/likelion/RePlay/domain/learning/web/controller/LearningController.java
@@ -118,4 +118,9 @@ public class LearningController {
         return learningService.getMentorReview(mentorReviewRequestDto);
     }
 
+    // 신청자 조회
+    @GetMapping("/getApplicant/{learningId}")
+    private ResponseEntity<CustomAPIResponse<?>> getApplicant(@PathVariable Long learningId, @AuthenticationPrincipal MyUserDetailsService.MyUserDetails userDetails) {
+        return learningService.getApplicant(learningId, userDetails);
+    }
 }


### PR DESCRIPTION
## 📄 제목
배움터 게시글 참가자 정보 조회 API

## 📖 설명
관리자는 참가 신청자들의 정보를 조회할 수 있다.

## 🔍 관련 이슈
- 관련 이슈: #120 

## 🛠️ 변경 사항
- [x] LearningApplyRepository learningId를 이용한 쿼리문 추가
- [x] LearningServiceImpl 기능에 맞게 작성

## ✅ 체크리스트
PR을 제출하기 전에 완료해야 할 항목들을 나열해주세요.
- [x] 코드가 컴파일 및 빌드됨
- [x] 모든 테스트가 통과함
- [x] 관련 문서가 업데이트됨
- [x] 코드 리뷰가 수행됨
